### PR TITLE
Pull the 3.0.10 RC3 with some bug fix to PsychJava installation.

### DIFF
--- a/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
+++ b/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
@@ -477,10 +477,10 @@ if ~IsOctave
             % Look for the first instance of PsychJava in the classpath and
             % replace it with the new one.  All other instances will be
             % ignored.
-            if isempty(strfind('PsychJava', fileContents{i}))
+            if isempty(strfind(fileContents{i}, 'PsychJava'))
                 newFileContents{j, 1} = fileContents{i}; %#ok<AGROW>
                 j = j + 1;
-            elseif ~isempty(strfind('PsychJava', fileContents{i})) & ~pathInserted %#ok<AND2>
+            elseif ~isempty(strfind(fileContents{i}, 'PsychJava')) & ~pathInserted %#ok<AND2>
                 newFileContents{j, 1} = path_PsychJava; %#ok<AGROW>
                 pathInserted = 1;
                 j = j + 1;


### PR DESCRIPTION
Replacing findstr with strfind had a bad side-effect, as now order of
arguments matters. Duh.
