### PR TITLE
pull removed unneeded rmpath()

### DIFF
--- a/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
+++ b/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
@@ -409,7 +409,6 @@ if IsWin & ~IsOctave %#ok<AND2>
     
     try
         % Remove DLL folders from path:
-        rmpath([PsychtoolboxRoot 'PsychBasic\MatlabWindowsFilesR11\']);
         rmpath([PsychtoolboxRoot 'PsychBasic\MatlabWindowsFilesR2007a\']);
         
         % Is this a Release2007a or later Matlab?


### PR DESCRIPTION
PsychBasic\MatlabWindowsFilesR11 has been removed, so no need to
rmpath() it. This generated a warning during install...
