### PR TITLE
Attach thread input in MATLAB 2012b

### DIFF
--- a/PsychSourceGL/Source/Windows/Screen/PsychWindowGlue.c
+++ b/PsychSourceGL/Source/Windows/Screen/PsychWindowGlue.c
@@ -318,7 +318,7 @@ BOOL CALLBACK PsychHostWindowEnumFunc(HWND hwnd, LPARAM passId)
 	#ifndef PTBOCTAVE3MEX
 		// Running on Matlab: Use Matlab name matching:
 		// Pass 1: Scan for Matlab in GUI mode:
-		if ((passId == 1) && strstr(hostwinName, "MATLAB  ")) {
+		if ((passId == 1) && (strstr(hostwinName, "MATLAB  ") || strstr(hostwinName, "MATLAB R20"))) {
 			// Found something that looks ok:
 			hostwinHandle = hwnd;
 			return(FALSE);


### PR DESCRIPTION
In MATLAB 2012b, the main window is named "MATLAB R2012b", with only a single space, so `PsychHostWindowEnumFunc` couldn't find it.
