### PR TITLE
Build fix for moglcore on NeuroDebian et al.

### DIFF
--- a/PsychSourceGL/Source/linuxmakeitoctave3_ubuntugutsy.m
+++ b/PsychSourceGL/Source/linuxmakeitoctave3_ubuntugutsy.m
@@ -129,7 +129,7 @@ if mode==6000
     curdir = pwd;
     cd('../../Psychtoolbox/PsychOpenGL/MOGL/source/')
     try
-       mex -v -g --output moglcore.mex -DLINUX -DGLEW_STATIC -DPTBOCTAVE3MEX -I/usr/X11R6/include -L/usr/X11R6/lib -lc -lGLESv1_CM -lGL -lGLU -lglut moglcore.c gl_auto.c gl_manual.c glew.c mogl_rebinder.c ftglesGlue.c
+       mex -v -g --output moglcore.mex -DPTB_USE_WAFFLE -DLINUX -DGLEW_STATIC -DPTBOCTAVE3MEX -I/usr/X11R6/include -L/usr/X11R6/lib -lc -lGLESv1_CM -lGL -lGLU -lglut moglcore.c gl_auto.c gl_manual.c glew.c mogl_rebinder.c ftglesGlue.c
     catch
     end
     unix(['mv moglcore.mex ' PsychtoolboxRoot target]);

--- a/Psychtoolbox/PsychOpenGL/MOGL/source/moglcore.c
+++ b/Psychtoolbox/PsychOpenGL/MOGL/source/moglcore.c
@@ -189,7 +189,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         // auto-detect and dynamically link/bind all core OpenGL functionality
         // as well as all possible OpenGL extensions on OS-X, Linux and Windows.
         err = GLEW_OK;
-        #ifdef LINUX
+        #ifdef PTB_USE_WAFFLE
         // Linux is special: If we use the Waffle backend for display system binding, then our display backend
         // may be something else than GLX (e.g., X11/EGL, Wayland/EGL, GBM/EGL, ANDROID/EGL etc.), in which case
         // glewInit() would not work and would crash hard. Detect if we're on classic Linux or Linux with X11/GLX.
@@ -205,7 +205,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
             err = glewContextInit();
         }
         #else
-            // Other os'es: Always init GLEW:
+            // Other os'es, or Linux without Waffle backend: Always init GLEW:
             err = glewInit();
         #endif
 


### PR DESCRIPTION
Use a #ifdef PTB_USE_WAFFLE instead of #ifdef LINUX to only enable the
special GLEW init code path for Linux if libwaffle is in use and we
therefore also employ our own patched GLEW library. This is important
because only our own GLEW version exports the function
glewContextInit(), but not a standard libGLEW v1.9, as used by
NeuroDebian/Debian/Ubuntu builds.

Default to classic "textbook" path which calls glewInit().
-> Should fix NeuroDebian build failure, does not require a new
standard PTB release.
