### PR TITLE
adding IBEAM cursor to selectable cursors in Windows

### DIFF
--- a/PsychSourceGL/Source/Common/Screen/SCREENShowCursorHelper.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENShowCursorHelper.c
@@ -206,7 +206,7 @@ PsychError SCREENShowCursorHelper(void)
                 break;
 
             case 8:
-                // No cursor:
+                // IBeam/text cursor:
                 lpCursorName = IDC_IBEAM;
                 break;
 

--- a/PsychSourceGL/Source/Common/Screen/SCREENShowCursorHelper.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENShowCursorHelper.c
@@ -205,6 +205,11 @@ PsychError SCREENShowCursorHelper(void)
                 lpCursorName = IDC_NO;
                 break;
 
+            case 8:
+                // No cursor:
+                lpCursorName = IDC_IBEAM;
+                break;
+
             default:
                 // Default for unknown id is the standard arrow cursor:
                 lpCursorName = IDC_ARROW;

--- a/Psychtoolbox/PsychBasic/ShowCursor.m
+++ b/Psychtoolbox/PsychBasic/ShowCursor.m
@@ -20,6 +20,7 @@ function oldType = ShowCursor(type, screenid, mouseid)
 % 'CrossHair' = A cross-hair cursor.
 % 'Hand' = A hand symbol.
 % 'SandClock' = Some sort of sand clock/hour-glass (not available on OSX).
+% 'TextCursor' = A text selection/caret placement cursor (AKA I Beam).
 %
 % Apart from that names, you can pass integral numbers for type to select
 % further shapes. The mapping of numbers to shapes is operating system
@@ -58,6 +59,7 @@ function oldType = ShowCursor(type, screenid, mouseid)
 % 09/21/07 mk  Added code for selecting 'type' - the shape of a cursor - on supported systems.
 % 08/14/14 dcn Fixed typo and simplified
 % 01/13/15 mk  Update help text to match reality better, esp. OSX.
+% 05/19/15 dcn Adding 'TextCursor' as now supported on all platforms.
 
 % We default to setup of display screen zero, if no
 % screenid provided. This argument is ignored on
@@ -126,6 +128,19 @@ else
 
             if IsLinux
                 type = 26;
+            end
+        end
+
+        if strcmpi(type, 'TextCursor');
+            % True for Windows:
+            type = 8;
+            
+            if IsOSX
+                type = 4;
+            end
+
+            if IsLinux
+                type = 1;
             end
         end
 

--- a/Psychtoolbox/PsychBasic/ShowCursor.m
+++ b/Psychtoolbox/PsychBasic/ShowCursor.m
@@ -24,7 +24,7 @@ function oldType = ShowCursor(type, screenid, mouseid)
 % Apart from that names, you can pass integral numbers for type to select
 % further shapes. The mapping of numbers to shapes is operating system
 % dependent, therefore not portable across different platforms. On
-% MS-Windows, you can select between number 0 to 7. On Linux/X11 you can
+% MS-Windows, you can select between number 0 to 8. On Linux/X11 you can
 % select from a wide range of numbers from 0 up to (at least) 152, maybe
 % more, depending on your setup. See the C header file "X11/cursorfont.h"
 % for a mapping of numbers to shapes. Passing invalid numbers can create


### PR DESCRIPTION
needed this, am building a selectable textbox for user input ;)
Untested as I don't have a build setup for psychtoolbox, but IDC_IBEAM is as found here: https://msdn.microsoft.com/en-us/library/windows/desktop/ms648391(v=vs.85).aspx