### PR TITLE
Small fixups

### DIFF
--- a/Psychtoolbox/PsychFiles/Var2Str.m
+++ b/Psychtoolbox/PsychFiles/Var2Str.m
@@ -112,6 +112,9 @@ elseif isempty(input) || ndims(input)<=2
         str = mat2str(input,17,'class');
     end
     str = regexprep(str,'\s+',' ');
+    % check for "Infi" which is an infinity imaginary component.
+    % to recreate that, we need to replace it with: complex(0, inf)
+    str = strrep(str,'Infi','complex(0, inf)');
 else
     psychassert(nargin==2,'input argument name must be defined if processing 2D+ matrix');
     str = mat2strhd(input,name);

--- a/Psychtoolbox/PsychOneliners/Ask.m
+++ b/Psychtoolbox/PsychOneliners/Ask.m
@@ -28,13 +28,13 @@ function reply=Ask(window,message,textColor,bgColor,replyFun,rectAlign1,rectAlig
 %
 % See also GetString.
 
-% 3/9/97  dgp	Wrote it, based on dhb's WaitForClick.m
+% 3/9/97   dgp	Wrote it, based on dhb's WaitForClick.m
 % 3/19/00  dgp	Suggest turning off font smoothing. Default colors.
 % 8/14/04  dgp	As suggested by Paul Thiem, added an example (and better argument checking) 
 %               to make it clear that replyFun must be supplied as a string and rectAlign1 as a value.
 % 8/14/04  dgp	Call Screen 'WindowToFront'.
 % 1/19/07  asg  Modified to work in OSX (for asg's purposes).
-% 6/6/07   mk   remove Screen('WindowToFron') unsupported on PTB-3, other
+% 6/6/07   mk   remove Screen('WindowToFront') unsupported on PTB-3, other
 %               small fixes...
 
 dontClear = 1;

--- a/Psychtoolbox/PsychTests/UnitTestRunAll.m
+++ b/Psychtoolbox/PsychTests/UnitTestRunAll.m
@@ -18,7 +18,7 @@ end
 
 % build function handles for each
 funs = {utests.fname};
-funs = cellfun(@str2func,funs,'UniformOutput',false);
+funs = cellfun(@str2func,funs,'uni',false);
 
 % run each
 nfailed = 0;

--- a/Psychtoolbox/PsychTests/UnitTests/Files_Test_FileFromFolder.m
+++ b/Psychtoolbox/PsychTests/UnitTests/Files_Test_FileFromFolder.m
@@ -45,10 +45,9 @@ try
         fprintf('FolderFromFolder didn''t get the right folder\n');
     end
     
-catch
+catch me
     success = false;
-    fprintf('error ocurred: "%s"\n',lasterr);
-    
+    fprintf('Unit test %s failed, error ocurred:\n%s\n',mfilename,me.getReport());
 end
 
 % cleanup

--- a/Psychtoolbox/PsychTests/UnitTests/Files_Test_FileVar2Str.m
+++ b/Psychtoolbox/PsychTests/UnitTests/Files_Test_FileVar2Str.m
@@ -75,13 +75,9 @@ try
     success = LogVarTester(h,'h') && success;
     
     
-catch
+catch me
     success = false;
-    err = lasterror;
-    fprintf('error ocurred: "%s"\nstack:\n',err.message);
-    for p=1:length(err.stack)
-        fprintf('Error in ==> %s at %d\n',err.stack(p).name,err.stack(p).line);
-    end
+    fprintf('Unit test %s failed, error ocurred:\n%s\n',mfilename,me.getReport());
 end
 
 
@@ -91,7 +87,7 @@ end
 function [success,var2,str] = Var2StrTester(var,name) %#ok<STOUT>
 str = Var2Str(var,'var2');
 eval(str);
-if ~isequalwithequalnans(var,var2)
+if ~isequaln(var,var2)
     success = false;
     fprintf('Var2Str failed on variable %s\n',name);
 else
@@ -105,7 +101,7 @@ str = fread(fid,inf,'*char');
 fclose(fid);
 delete(fullfile(cd,fname));
 eval(str);
-if ~isequalwithequalnans(var,var2)
+if ~isequaln(var,var2)
     success = false;
     fprintf('LogVar failed on variable %s\n',name);
 else

--- a/Psychtoolbox/PsychTests/UnitTests/Files_Test_LineTerminators.m
+++ b/Psychtoolbox/PsychTests/UnitTests/Files_Test_LineTerminators.m
@@ -30,9 +30,9 @@ try
     % two terminators in a row, so empty line->cell in between
     success = tester(BreakLines(d),{'1' char(zeros(1,0)) '2'},'BreakLines(d)') && success;
     
-catch
+catch me
     success = false;
-    fprintf('error ocurred: "%s"\n',lasterr);
+    fprintf('Unit test %s failed, error ocurred:\n%s\n',mfilename,me.getReport());
 end
 
 

--- a/Psychtoolbox/PsychTests/UnitTests/Oneliners_Test_Structs.m
+++ b/Psychtoolbox/PsychTests/UnitTests/Oneliners_Test_Structs.m
@@ -141,8 +141,7 @@ try
     clear out
     
     
-catch
+catch me
     success = false;
-    fprintf('error ocurred: "%s"\n',lasterr);
-    
+    fprintf('Unit test %s failed, error ocurred:\n%s\n',mfilename,me.getReport());
 end


### PR DESCRIPTION
Running the unit tests i spotted one that failed on current matlab. Fixing Var2Str to address that. Fix would not affect older version that apparently don't produce 'Infi' values (hey, test used to pass...)
Also updated unit tests scripts a bit and random other typo fix