### PR TITLE
GetMouseIndices: Add option 'slavePointers'

### DIFF
--- a/Psychtoolbox/PsychHardware/GetMouseIndices.m
+++ b/Psychtoolbox/PsychHardware/GetMouseIndices.m
@@ -5,9 +5,9 @@ function [mouseIndices, productNames, allInfo]= GetMouseIndices(typeOnly)
 %
 % PsychHID assigns each USB HID device connected to you computer a unique
 % index. GetMouseIndices returns the indices for those HID devices which
-% are mouses.  The product names of the mouses are returned in a second
+% are mouses. The product names of the mouses are returned in a second
 % argument which is useful to identify the mouse associated with a
-% paticular index.  For complete information on a gampad use
+% paticular index. For complete information on a gampad use
 % PsychHID('Devices').
 %
 % LINUX: __________________________________________________________________
@@ -15,7 +15,11 @@ function [mouseIndices, productNames, allInfo]= GetMouseIndices(typeOnly)
 % GetMouseIndices allows selection of different types of pointing devices
 % via the optional 'typeOnly' argument:
 % 'masterPointer' will only return indices of so called "master pointer"
-% devices. These correspond to visible mouse cursors.
+% devices. These correspond to visible mouse cursors. 'slavePointer' will
+% only return indices of slave pointer devices. If you want to use keyboard
+% query functions like KbCheck, KbQueueCheck etc. to get mouse button presses,
+% then you can only use slave pointer devices, ie., select between mice that
+% are returned by setting 'typeOnly' as 'slavePointer'.
 %
 % WINDOWS: ________________________________________________________________
 % 
@@ -25,8 +29,9 @@ function [mouseIndices, productNames, allInfo]= GetMouseIndices(typeOnly)
 % see also: GetKeyboardIndices, GetKeypadIndices, GetGamepadIndices
 
 % HISTORY
-% 10/15/04  awi     Wrote it.  Based on GetGamepadIndices
-% 12/17/09  rpw		Added see also for GetKeypadIndices
+% 10/15/04  awi   Wrote it. Based on GetGamepadIndices
+% 12/17/09  rpw   Added see also for GetKeypadIndices
+% 08/27/15  mk    Add 'slavePointer' support.
 
 mouseIndices=[];
 productNames=cell(0);
@@ -40,6 +45,8 @@ if ~IsOSX
   LoadPsychHID;
   if strcmpi(typeOnly, 'masterPointer')
     d = PsychHID('Devices', 1);
+  elseif strcmpi(typeOnly, 'slavePointer')
+    d = PsychHID('Devices', 3);
   else
     d = [ PsychHID('Devices', 1) , PsychHID('Devices', 3) ];
   end


### PR DESCRIPTION
Need to be able to select for slavePointers only on Linux
(option is ignored on other OSes), because if mice are
used with KbCheck/KbQueue et al., then those functions will
only work on slavePointers, not masterPointers.