### PR TITLE
get compile log for shader when in debug mode

### DIFF
--- a/Psychtoolbox/PsychOpenGL/LoadShaderFromFile.m
+++ b/Psychtoolbox/PsychOpenGL/LoadShaderFromFile.m
@@ -97,7 +97,21 @@ else
     glShaderSource(handle, shadersrc);
 end;
 
-glCompileShader(handle);
+if debug > 1
+    % We need to temporarily raise moglcores debuglevel to 2 to get extended
+    % error/validation information:
+    oldDebug = InitializeMatlabOpenGL(-1);
+    moglcore('DEBUGLEVEL', 2);
+
+    % Compile the shader:
+    glCompileShader(handle);
+
+    % Restore old debuglevel for moglcore:
+    moglcore('DEBUGLEVEL', oldDebug);
+else
+    % Compile the shader without raised debug level for moglcore:
+    glCompileShader(handle);
+end
 
 % Done.
 return;


### PR DESCRIPTION
Like we do for linking, set the moglcore to debug mode when compiling a shader in debug mode