### PR TITLE
detachFromMouse not supported under Linux

### DIFF
--- a/Psychtoolbox/PsychBasic/SetMouse.m
+++ b/Psychtoolbox/PsychBasic/SetMouse.m
@@ -65,5 +65,8 @@ end
 if nargin < 5 || isempty(detachFromMouse)
   detachFromMouse = 0;
 end
-
-Screen('SetMouseHelper', windowPtrOrScreenNumber, round(x), round(y), mouseid, detachFromMouse);
+if isunix && ~ismac
+    Screen('SetMouseHelper', windowPtrOrScreenNumber, round(x), round(y), mouseid);
+else
+    Screen('SetMouseHelper', windowPtrOrScreenNumber, round(x), round(y), mouseid, detachFromMouse);
+end


### PR DESCRIPTION
This is true at least on Linux
SetMouse crashes because Screen('SetMouseHelper',... is expecting
Screen('SetMouseHelper', windowPntrOrScreenNumber, x, y [, mouseIndex]); 
and line 69 here has an additional detachFromMouse input.

using latest 'octave-psychtoolbox-3' on ubuntu

Practically, I'm not sure this is how I'm supposed to send you pull requests. Let me know if I'm mistaken.