### PR TITLE
added support for positive modulation only in gabor patches

### DIFF
--- a/Psychtoolbox/PsychGLImageProcessing/CreateProceduralGabor.m
+++ b/Psychtoolbox/PsychGLImageProcessing/CreateProceduralGabor.m
@@ -1,4 +1,4 @@
-function [gaborid, gaborrect] = CreateProceduralGabor(windowPtr, width, height, nonSymmetric, backgroundColorOffset, disableNorm, contrastPreMultiplicator)
+function [gaborid, gaborrect] = CreateProceduralGabor(windowPtr, width, height, nonSymmetric, backgroundColorOffset, disableNorm, contrastPreMultiplicator, onlyUsePositiveModulationShader)
 % [gaborid, gaborrect] = CreateProceduralGabor(windowPtr, width, height [, nonSymmetric=0][, backgroundColorOffset =(0,0,0,0)][, disableNorm=0][, contrastPreMultiplicator=1])
 %
 % Creates a procedural texture that allows to draw Gabor stimulus patches
@@ -146,12 +146,31 @@ if nargin < 7 || isempty(contrastPreMultiplicator)
     contrastPreMultiplicator = 1.0;
 end
 
+if nargin < 8 || isempty(onlyUsePositiveModulationShader)
+    % Good for use when modulating patch by color, and you don't want
+    % negative modulation effects
+    onlyUsePositiveModulationShader = 0;
+end
+
 if ~nonSymmetric
-    % Load standard symmetric support shader - Faster!
-    gaborShader = LoadGLSLProgramFromFiles('BasicGaborShader', debuglevel);
+    if onlyUsePositiveModulationShader
+        % Good for use when modulating patch by color, and you don't want
+        % negative modulation effects
+        gaborShader = LoadGLSLProgramFromFiles('PositivesOnlyBasicGaborShader', debuglevel);
+    else
+        % Load standard symmetric support shader - Faster than asymmetric!
+        gaborShader = LoadGLSLProgramFromFiles('BasicGaborShader', debuglevel);
+    end
+    
 else
-    % Load extended asymmetric support shader - Slower!
-    gaborShader = LoadGLSLProgramFromFiles('NonSymetricGaborShader', debuglevel);
+    if onlyUsePositiveModulationShader
+        % Good for use when modulating patch by color, and you don't want
+        % negative modulation effects
+        gaborShader = LoadGLSLProgramFromFiles('PositivesOnlyNonSymetricGaborShader', debuglevel);
+    else
+        % Load extended asymmetric support shader - Slower!
+        gaborShader = LoadGLSLProgramFromFiles('NonSymetricGaborShader', debuglevel);
+    end
 end
 
 % Setup shader:

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyBasicGaborShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyBasicGaborShader.frag.txt
@@ -1,0 +1,45 @@
+/*
+ * File: PositivesOnlyBasicGaborShader.frag.txt
+ * Shader for drawing of basic parameterized gabor patches.
+ * Only show positive values in final grating.
+ *
+ * This is the fragment shader. It gets the per-patch-constant
+ * parameters as varyings from the vertex shader and hardware
+ * interpolators, then performs per fragment calculations to
+ * compute and write the final pixel color.
+ *
+ * (c) 2007 by Mario Kleiner, licensed under MIT license.
+ *		 
+ */
+
+uniform vec4 Offset;
+
+varying float Angle;
+varying vec4  baseColor;
+varying float Phase;
+varying float FreqTwoPi;
+varying float Expmultiplier;
+
+void main()
+{
+    /* Query current output texel position wrt. to Center of Gabor: */
+    vec2 pos = gl_TexCoord[0].xy;
+
+    /* Compute (x,y) distance weighting coefficients, based on rotation angle: */
+    /* Note that this is a constant for all fragments, but we can not do it in */
+    /* the vertex shader, because the vertex shader does not have sufficient   */
+    /* numeric precision on some common hardware out there. */
+    vec2 coeff = vec2(cos(Angle), sin(Angle)) * FreqTwoPi;
+
+    /* Evaluate sine grating at requested position, angle and phase: */
+    float sv = sin(dot(coeff, pos) + Phase);
+
+    /* Compute exponential hull for the gabor: */
+    float ev = exp(dot(pos, pos) * Expmultiplier);
+
+    /* Multiply/Modulate base color and alpha with calculated sine/gauss      */
+    /* values, add some constant color/alpha Offset, assign as final fragment */
+    /* output color: */
+    /*gl_FragColor = (baseColor * (ev * sv )) + Offset;*/
+    gl_FragColor = (baseColor * clamp(ev * sv, 0.0, 1.0 )) + Offset;
+}

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyBasicGaborShader.vert.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyBasicGaborShader.vert.txt
@@ -1,0 +1,71 @@
+/*
+ * File: PositivesOnlyBasicGaborShader.vert.txt
+ * Shader for drawing of basic parameterized gabor patches.
+ *
+ * This is the vertex shader. It takes the attributes (parameters)
+ * provided by the Screen('DrawTexture(s)') command, performs some
+ * basic calculations on it - the calculations that only need to be
+ * done once per gabor patch and that can be reliably carried out
+ * at sufficient numeric precision in a vertex shader - then it passes
+ * results of computations and other attributes as 'varying' parameters
+ * to the fragment shader.
+ *
+ * (c) 2007 by Mario Kleiner, licensed under MIT license.
+ *		 
+ */
+
+/* Constants that we need 2*pi and square-root of 2*pi: */
+const float twopi     = 2.0 * 3.141592654;
+const float sqrtof2pi = 2.5066282746;
+
+/* Conversion factor from degrees to radians: */
+const float deg2rad = 3.141592654 / 180.0;
+
+/* Texel position of center of gabor patch: Constant, set from Matlab */
+/* once when the shader is created: */
+uniform vec2  Center;
+
+/* If disableNorm is set to 1.0, then the normalization term below is    */
+/* not applied to the gabors final values. Default is 0.0, ie. apply it. */
+uniform float disableNorm;
+
+/* Constant from setup code: Premultiply to contrast value: */
+uniform float contrastPreMultiplicator;
+
+/* Attributes passed from Screen(): See the ProceduralShadingAPI.m file for infos: */
+attribute vec4 sizeAngleFilterMode;
+attribute vec4 modulateColor;
+attribute vec4 auxParameters0;
+
+/* Information passed to the fragment shader: Attributes and precalculated per patch constants: */
+varying float Angle;
+varying vec4  baseColor;
+varying float Phase;
+varying float FreqTwoPi;
+varying float Expmultiplier;
+
+void main()
+{
+    /* Apply standard geometric transformations to patch: */
+    gl_Position = ftransform();
+
+    /* Don't pass real texture coordinates, but ones corrected for hardware offsets (-0.5,0.5) */
+    /* and so that the center of the gabor patch has coordinate (0,0): */
+    gl_TexCoord[0] = gl_MultiTexCoord0 - vec4(Center, 0.0, 0.0) + vec4(-0.5, 0.5, 0.0, 0.0);
+
+    /* Contrast value is stored in auxParameters0[3]: */
+    float Contrast = auxParameters0[3];
+    /* Convert Angle and Phase from degrees to radians: */
+    Angle = deg2rad * sizeAngleFilterMode.z;
+    Phase = deg2rad * auxParameters0[0];
+    /* Precalc a couple of per-patch constant parameters: */
+    FreqTwoPi = auxParameters0[1] * twopi;
+    float SpaceConstant = auxParameters0[2];
+    Expmultiplier = -0.5 / (SpaceConstant * SpaceConstant);
+
+    /* Conditionally apply non-standard normalization term iff disableNorm == 0.0 */
+    float mc = disableNorm + (1.0 - disableNorm) * (1.0 / (sqrtof2pi * SpaceConstant));
+
+    /* Premultiply the wanted Contrast to the color: */
+    baseColor = modulateColor * mc * Contrast * contrastPreMultiplicator;
+}

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyNonSymetricGaborShader.frag.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyNonSymetricGaborShader.frag.txt
@@ -1,0 +1,53 @@
+/*
+ * File: PositivesOnlyNonSymetricGaborShader.frag.txt
+ * Shader for drawing of parameterized gabor patches that are allowed to
+ * be elliptical, ie. non-circular, ie., aspect ration != 1.
+ *
+ * This is the fragment shader. It gets the per-patch-constant
+ * parameters as varyings from the vertex shader and hardware
+ * interpolators, then performs per fragment calculations to
+ * compute and write the final pixel color.
+ *
+ * (c) 2007, 2008 by Mario Kleiner, licensed under MIT license.
+ *		 
+ */
+
+#extension GL_ARB_texture_rectangle : enable
+
+uniform vec4 Offset;
+
+varying float Angle;
+varying vec4  baseColor;
+varying float Phase;
+varying float FreqTwoPi;
+varying float Expmultiplier;
+varying float GammaSquared;
+
+void main()
+{
+    /* Compute sine and cosine coefficients, based on rotation angle: */
+    /* Note that this is a constant for all fragments, but we can not do it in */
+    /* the vertex shader, because the vertex shader does not have sufficient   */
+    /* numeric precision on some common hardware out there. */
+    float st = sin(Angle);
+    float ct = cos(Angle);
+
+    /* Query current output texel position wrt. to Center of Gabor: */
+    vec2 pos = gl_TexCoord[0].xy;
+
+    /* Compute x' and y' terms: */
+    float xdash = dot(vec2( ct, st), pos);
+    float ydash = dot(vec2(-st, ct), pos);
+
+    /* Evaluate sine grating at requested position, angle and phase: */
+    float sv = sin(xdash * FreqTwoPi + Phase);
+
+    /* Compute exponential hull for the gabor: */
+    float ev = exp(((xdash * xdash)  + (GammaSquared * ydash * ydash)) * Expmultiplier);
+
+    /* Multiply/Modulate base color and alpha with calculated sine/gauss      */
+    /* values, add some constant color/alpha Offset, assign as final fragment */
+    /* output color: */
+    /*gl_FragColor = (baseColor * (ev * sv )) + Offset;*/
+    gl_FragColor = (baseColor * clamp(ev * sv, 0.0, 1.0 )) + Offset;
+}

--- a/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyNonSymetricGaborShader.vert.txt
+++ b/Psychtoolbox/PsychOpenGL/PsychGLSLShaders/PositivesOnlyNonSymetricGaborShader.vert.txt
@@ -1,0 +1,82 @@
+/*
+ * File: PositivesOnlyNonSymetricGaborShader.vert.txt
+ * Shader for drawing of parameterized gabor patches that are allowed to
+ * be elliptical, ie. non-circular, ie., aspect ration != 1.
+ *
+ * This is the vertex shader. It takes the attributes (parameters)
+ * provided by the Screen('DrawTexture(s)') command, performs some
+ * basic calculations on it - the calculations that only need to be
+ * done once per gabor patch and that can be reliably carried out
+ * at sufficient numeric precision in a vertex shader - then it passes
+ * results of computations and other attributes as 'varying' parameters
+ * to the fragment shader.
+ *
+ * (c) 2007, 2008 by Mario Kleiner, licensed under MIT license.
+ *		 
+ */
+
+/* Constants that we need 2*pi and square-root of 2*pi: */
+const float twopi     = 2.0 * 3.141592654;
+const float sqrtof2pi = 2.5066282746;
+
+/* Conversion factor from degrees to radians: */
+const float deg2rad = 3.141592654 / 180.0;
+
+/* Texel position of center of gabor patch: Constant, set from Matlab */
+/* once when the shader is created: */
+uniform vec2  Center;
+
+/* If disableNorm is set to 1.0, then the normalization term below is    */
+/* not applied to the gabors final values. Default is 0.0, ie. apply it. */
+uniform float disableNorm;
+
+/* Constant from setup code: Premultiply to contrast value: */
+uniform float contrastPreMultiplicator;
+
+/* Attributes passed from Screen(): See the ProceduralShadingAPI.m file for infos: */
+attribute vec4 sizeAngleFilterMode;
+attribute vec4 modulateColor;
+attribute vec4 auxParameters0;
+attribute vec4 auxParameters1;
+
+/* Information passed to the fragment shader: Attributes and precalculated per patch constants: */
+varying float Angle;
+varying vec4  baseColor;
+varying float Phase;
+varying float FreqTwoPi;
+varying float Expmultiplier;
+varying float GammaSquared;
+
+void main()
+{
+    /* Apply standard geometric transformations to patch: */
+    gl_Position = ftransform();
+
+    /* Don't pass real texture coordinates, but ones corrected for hardware offsets (-0.5,0.5) */
+    /* and so that the center of the gabor patch has coordinate (0,0): */
+    gl_TexCoord[0] = gl_MultiTexCoord0 - vec4(Center, 0.0, 0.0) + vec4(-0.5, 0.5, 0.0, 0.0);
+
+    /* Contrast value is stored in auxParameters0[3]: */
+    float Contrast = auxParameters0[3];
+
+    /* Convert Angle and Phase from degrees to radians: */
+    Angle = deg2rad * sizeAngleFilterMode.z;
+    Phase = deg2rad * auxParameters0[0];
+
+    /* Precalc a couple of per-patch constant parameters: */
+    FreqTwoPi = auxParameters0[1] * twopi;
+
+    float SpaceConstant = auxParameters0[2];
+    Expmultiplier = -0.5 / (SpaceConstant * SpaceConstant);
+
+
+    /* Conditionally apply non-standard normalization term iff disableNorm == 0.0 */
+    float mc = disableNorm + (1.0 - disableNorm) * (1.0 / (sqrtof2pi * SpaceConstant));
+
+    /* The spatial aspect ratio Gamma is stored in the 5th aux parameter. */
+    float Gamma = auxParameters1[0];
+    GammaSquared = Gamma * Gamma;
+
+    /* Premultiply the wanted Contrast to the color: */
+    baseColor = modulateColor * mc * Contrast * contrastPreMultiplicator;
+}


### PR DESCRIPTION
@kleinerm When using CreateProceduralGabor and Screen('DrawTextures') to show gabor patches, there are inherently negative values present when modulating the gabor by a given color (due to the nature of gabors). Here, I've added and 8th argument to the function CreateProceduralGabor that specifies if you want to remove negative modulation effects (which is important when adding colors to gabors). If left empty, or not passed in, the function will operate as it previously did. 

I've also made two new shaders that support clamping the color to values between 0..1. These shaders are called from CreateProceduralGabor if the 8th argument "onlyUsePositiveModulationShader" is set to true. 