### PR TITLE
Pull minor fixes for 3.0.13

### DIFF
--- a/PsychSourceGL/Cohorts/PsychtoolboxOSXKernelDriver/PsychtoolboxKernelDriver.cpp
+++ b/PsychSourceGL/Cohorts/PsychtoolboxOSXKernelDriver/PsychtoolboxKernelDriver.cpp
@@ -637,51 +637,63 @@ bool PsychtoolboxKernelDriver::start(IOService* provider)
         reg0 = ReadRegister(NV03_PMC_BOOT_0);
 
         /* We're dealing with >=NV10 */
-        if ((reg0 & 0x0f000000) > 0) {
-            /* Bit 27-20 contain the architecture in hex */
-            chipset = (reg0 & 0xff00000) >> 20;
+        if ((reg0 & 0x1f000000) > 0) {
+            /* Bit 28-20 contain the architecture in hex */
+            chipset = (reg0 & 0x1ff00000) >> 20;
             /* NV04 or NV05 */
         } else if ((reg0 & 0xff00fff0) == 0x20004000) {
             if (reg0 & 0x00f00000)
                 chipset = 0x05;
             else
                 chipset = 0x04;
-        } else {
+        } else
             chipset = 0xff;
-        }
 
-        switch (chipset & 0xf0) {
-            case 0x00:
+        switch (chipset & 0x1f0) {
+            case 0x000:
                 // NV_04/05: RivaTNT , RivaTNT2
                 fCardType = 0x04;
                 break;
-            case 0x10:
-            case 0x20:
-            case 0x30:
+            case 0x010:
+            case 0x020:
+            case 0x030:
                 // NV30 or earlier: GeForce-5 / GeForceFX and earlier:
                 fCardType = chipset & 0xf0;
                 break;
-            case 0x40:
-            case 0x60:
-                // NV40: GeForce6/7 series: "Curie"
-                fCardType = 0x40;
+            case 0x040:
+            case 0x060:
+                // NV40: GeForce6/7 series:
+                fCardType = 0x040;
                 break;
-            case 0x50:
-            case 0x80:
-            case 0x90:
-            case 0xa0:
-                // NV50: GeForce8/9/Gxxx: "Tesla"
-                fCardType = 0x50;
+            case 0x050:
+            case 0x080:
+            case 0x090:
+            case 0x0a0:
+                // NV50: GeForce8/9/G100-G300.
+                fCardType = 0x050;
                 break;
-            case 0xc0:
-                // NVC0: GeForce-400/500: "Fermi"
-                fCardType = 0xc0;
+            case 0x0c0:
+                // Fermi: GeForce G400/500 series:
+                fCardType = 0x0c0;
                 break;
-            case 0xd0:
-            case 0xe0:
-            case 0xf0:
-                // NVE0: GeForce-600: "Kepler"
-                fCardType = 0xe0;
+            case 0x0d0:
+                // Fermi: But with 3rd gen scanout engine, but still only 2 CRTC's:
+                fCardType = 0x0d0;
+                break;
+            case 0x0e0:
+            case 0x0f0:
+            case 0x100:
+                // Kepler: GeForce G600+ series: 3rd gen scanout engine, but now up to 4 CRTC's.
+                fCardType = 0x0e0;
+                break;
+            case 0x110:
+            case 0x120:
+                // Maxwell: GeForce 750+ series: 3rd gen scanout engine, up to 4 CRTC's.
+                fCardType = 0x110;
+                break;
+            case 0x130:
+                // Pascal: GeForce 1000+ series: 3rd gen scanout engine, up to 4 CRTC's.
+                fCardType = 0x130;
                 break;
             default:
                 IOLog("%s: Unknown NVidia chipset 0x%08x. Optimistically assuming latest generation GPU too new to be known.\n", getName(), reg0);
@@ -691,7 +703,7 @@ bool PsychtoolboxKernelDriver::start(IOService* provider)
         // "Kepler" chip family and later supports 4 display heads:
         if ((fCardType == 0x0) || (fCardType >= 0xe0)) fNumDisplayHeads = 4;
 
-        if (fCardType > 0x00) IOLog("%s: NV-%02x GPU with %d display heads detected.\n", getName(), fCardType, fNumDisplayHeads);
+        if (fCardType > 0x00) IOLog("%s: NV-%03x family GPU with %d display heads detected.\n", getName(), fCardType, fNumDisplayHeads);
     }
 
     // The following code chunk if enabled, will detaching the Radeon driver IRQ handler and

--- a/PsychSourceGL/Source/Common/Screen/PsychGraphicsHardwareHALSupport.c
+++ b/PsychSourceGL/Source/Common/Screen/PsychGraphicsHardwareHALSupport.c
@@ -887,6 +887,11 @@ unsigned int PsychGetNVidiaGPUType(PsychWindowRecordType* windowRecord)
             // Maxwell: GeForce 750+ series: 3rd gen scanout engine, up to 4 CRTC's.
             card_type = 0x110;
             break;
+        case 0x130:
+            // Pascal: GeForce 1000+ series: 3rd gen scanout engine, up to 4 CRTC's.
+            card_type = 0x130;
+            break;
+
         default:
             printf("PTB-DEBUG: Unknown NVidia chipset 0x%08x - Assuming latest generation.\n", reg0);
             card_type = 0x000;

--- a/PsychSourceGL/Source/Linux/Screen/PsychScreenGlue.c
+++ b/PsychSourceGL/Source/Linux/Screen/PsychScreenGlue.c
@@ -1342,6 +1342,7 @@ void InitCGDisplayIDList(void)
     char* ptbdisplays = NULL;
     char displayname[1000];
     CGDirectDisplayID x11_dpy = NULL;
+    char* ptbpipelines = NULL;
 
     // NULL-out array of displays:
     for(i=0;i<kPsychMaxPossibleDisplays;i++) displayCGIDs[i]=NULL;
@@ -1466,6 +1467,16 @@ void InitCGDisplayIDList(void)
     // set that flag, but we only want this flag set if triggered by true override from usercode by use of
     // Screen('Preference', 'ScreenToHead', screenId, ...):
     PsychResetCrtcIdUserOverride();
+
+    // Did user provide an override for the screenid --> pipeline mapping? Need to reapply it as it
+    // may have gotten clobbered by GetRandRScreenConfig() above:
+    ptbpipelines = getenv("PSYCHTOOLBOX_PIPEMAPPINGS");
+    if (ptbpipelines) {
+        // The default is "012...", ie screen 0 = pipe 0, 1 = pipe 1, 2 =pipe 2, n = pipe n
+        for (i = 0; (i < (int) strlen(ptbpipelines)) && (i < kPsychMaxPossibleDisplays); i++) {
+            PsychSetScreenToCrtcId(i, (((ptbpipelines[i] - 0x30) >=0) && ((ptbpipelines[i] - 0x30) < 10)) ? (ptbpipelines[i] - 0x30) : -1, 0);
+        }
+    }
 
     // Prepare atoms for "Desktop composition active?" queries:
     // Each atom corresponds to one X-Screen. It is selection-owned by the

--- a/Psychtoolbox/PsychDemos/RaspberryPiGPIODemo.m
+++ b/Psychtoolbox/PsychDemos/RaspberryPiGPIODemo.m
@@ -33,9 +33,16 @@ function RaspberryPiGPIODemo
 % use a M-File wrapper around it to simplify transition to a
 % future better I/O driver.
 %
+% All pin numbers used with RPiGPIOMex are Broadcom GPIO pin
+% numbers, not pin numbers on the connector or wiringPi pin numbers!
+%
+% A nice translation table between connector pins and Broadcom GPIO
+% pins can be found on the following website: https://pinout.xyz
+%
 
 % History:
 % 26-Jun-2016 mk  Written.
+% 22-Jul-2016 mk  Clarify pin numbering more, reference https://pinout.xyz
 
 % Get Pi revision. We only handle > 1 at the moment:
 revision = RPiGPIOMex

--- a/Psychtoolbox/PsychDocumentation/PTBSurvey.m
+++ b/Psychtoolbox/PsychDocumentation/PTBSurvey.m
@@ -24,4 +24,10 @@ function PTBSurvey
 %
 %  Thanks!
 
+try
+    fid = fopen([PsychtoolboxConfigDir 'surveydone'], 'w');
+    fclose(fid);
+catch
+end
+
 help PTBSurvey;

--- a/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusImagingPipelineTest.m
+++ b/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusImagingPipelineTest.m
@@ -179,12 +179,6 @@ for idx = 1:size(spo, 2)
 
     fprintf('ReadbackOffset (%i, %i): Maximum raw data difference: red= %f green = %f blue = %f\n', dx, dy, mdr, mdg, mdb);
 
-    % Perfect results?
-    if ((mdr == 0) && (mdg == 0) && (mdb == 0))
-        % Yep. Done!
-        break;
-    end
-
     % If there is a difference, show plotted difference if requested:
     if (mdr>0 || mdg>0 || mdb>0) && plotdiffs
         % Differences detected!
@@ -247,11 +241,17 @@ for idx = 1:size(spo, 2)
         % No error: Set maxdiff to zero.
         maxdiff = 0;
     end
-    
+
     % Compute absolute effective maximum error in color intensity over all
     % values, pixels and channels. This is the true "human visible" error.
     maxerror = max(maxdiff);
-    minerror = min(minerror, maxerror);
+
+    % Track minimum error and the settings that lead to it:
+    if maxerror < minerror
+        minerror = maxerror;
+        mindx = dx;
+        mindy = dy;
+    end
 
     % Error small enough to be acceptable for practical purposes?
     if maxerror <= acceptableerror
@@ -259,6 +259,10 @@ for idx = 1:size(spo, 2)
         break;
     end
 end
+
+% Move ahead with the dx,dy offsets that gave the best results:
+dx = mindx;
+dy = mindy;
 
 % Show GPU converted image. Should obviously not make any visual difference if
 % it is the same as the Matlab converted image.

--- a/Psychtoolbox/PsychHardware/CMUBox.m
+++ b/Psychtoolbox/PsychHardware/CMUBox.m
@@ -187,6 +187,8 @@ function varargout = CMUBox(cmd, handle, varargin)
 %                3 msecs. Some MS-Windows systems with FTDI Serial-to-USB
 %                converter go mildly above 2 msecs, e.g. by a few microseconds.
 %                Be tolerant and accept up to 3 msecs before reporting trouble.
+% 21.07.2016 mk  Add GetMouse calls in 'GetEvent' loop to avoid app-not-responding
+%                timeout problems on MS-Windows Vista+.
 
 % Cell array of structs for our boxes: One cell for each open box.
 persistent boxes;
@@ -242,6 +244,12 @@ if strcmpi(cmd, 'GetEvent')
     % for new events is requested, or - in non-blocking mode - new status
     % bytes from the box are available to parse:
     while (waitEvent > 0) || (IOPort('BytesAvailable', box.port) >= 9)
+        % A tribute to Windows: A useless call to GetMouse to trigger
+        % Screen()'s Windows application event queue processing to avoid
+        % white-death due to hitting the "Application not responding" timeout:
+        if IsWin
+            GetMouse;
+        end
 
         % Wait blocking for at least one status packet of 9 bytes from box:
         [inpkt, t, err] = IOPort('Read', box.port, 1, 9);

--- a/Psychtoolbox/PsychJava/PsychJavaSwingCleanup.m
+++ b/Psychtoolbox/PsychJava/PsychJavaSwingCleanup.m
@@ -47,7 +47,9 @@ end
 state = warning;
 try
     warning off;
-    delete([PsychtoolboxConfigDir 'screen_buildnr_*']);
+    if ~exist([PsychtoolboxConfigDir 'surveydone'], 'file')
+        delete([PsychtoolboxConfigDir 'screen_buildnr_*']);
+    end
 catch
 end
 warning(state);


### PR DESCRIPTION
* One time exec of PTBSurvey disables long nag screen.
* CMUBox Windows Vista+ compat fixes.
* BitsPlusImagingPipelineTest refinements for suboptimal setups.
* RaspberryPiGPIODemo: Add more infos about pin numbering.