### PR TITLE
DrawFormattedText's flipVertical now works with FTGL plugin

### DIFF
--- a/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
+++ b/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
@@ -95,7 +95,6 @@ bool _firstCall = true;
 bool _useOwnFontmapper = false;
 unsigned _mapperFlags;
 int _antiAliasing = 1;
-double _vxs, _vys, _vw, _vh;
 char _fontName[FILENAME_MAX] = { 0 };
 unsigned int _fontStyle = 0;
 double _fontSize = 0.0;
@@ -450,11 +449,7 @@ void PsychSetTextBGColor(int context, double* color)
 // renderbackend needs a different geometric setup:
 void PsychSetTextViewPort(int context, double xs, double ys, double w, double h)
 {
-    _vxs = xs;
-    _vys = ys;
-    _vw  = w;
-    _vh  = h;
-
+    // no-op for this plugin
     return;
 }
 
@@ -564,11 +559,12 @@ int PsychDrawText(int context, double xStart, double yStart, int textLen, double
     glEnable( GL_TEXTURE_2D );
     glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE );
 
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(_vxs, _vxs + _vw, _vys, _vys + _vh);
     glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    // FTGL assumes bottom-left origin, our projection matrix has top-left origin: flip text vertically
+    glTranslated(0., yStart, 0.);
+    glScaled(1., -1., 1.);
+    glTranslated(0, -yStart, 0.);
 
     // Set text color: This will be filtered by OGLFT for redundant settings:
     if (fi->faceT) {
@@ -610,9 +606,7 @@ int PsychDrawText(int context, double xStart, double yStart, int textLen, double
     // Disable alpha test after blit:
     glDisable(GL_ALPHA_TEST);
 
-    glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
     glDisable( GL_TEXTURE_2D );
     glPopAttrib();
     glPopClientAttrib();

--- a/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
+++ b/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
@@ -95,6 +95,7 @@ bool _firstCall = true;
 bool _useOwnFontmapper = false;
 unsigned _mapperFlags;
 int _antiAliasing = 1;
+double _vxs, _vys, _vw, _vh;
 char _fontName[FILENAME_MAX] = { 0 };
 unsigned int _fontStyle = 0;
 double _fontSize = 0.0;
@@ -449,7 +450,11 @@ void PsychSetTextBGColor(int context, double* color)
 // renderbackend needs a different geometric setup:
 void PsychSetTextViewPort(int context, double xs, double ys, double w, double h)
 {
-    // no-op for this plugin
+    _vxs = xs;
+    _vys = ys;
+    _vw  = w;
+    _vh  = h;
+
     return;
 }
 

--- a/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
+++ b/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
@@ -564,6 +564,10 @@ int PsychDrawText(int context, double xStart, double yStart, int textLen, double
     glEnable( GL_TEXTURE_2D );
     glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE );
 
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    gluOrtho2D(_vxs, _vxs + _vw, _vys + _vh, _vys);
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     // FTGL assumes bottom-left origin, our projection matrix has top-left origin: flip text vertically
@@ -611,6 +615,9 @@ int PsychDrawText(int context, double xStart, double yStart, int textLen, double
     // Disable alpha test after blit:
     glDisable(GL_ALPHA_TEST);
 
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
     glPopMatrix();
     glDisable( GL_TEXTURE_2D );
     glPopAttrib();

--- a/PsychSourceGL/Source/Common/Screen/SCREENDrawText.c
+++ b/PsychSourceGL/Source/Common/Screen/SCREENDrawText.c
@@ -2188,7 +2188,7 @@ PsychError PsychDrawUnicodeText(PsychWindowRecordType* winRec, PsychRectType* bo
         }
         else {
             // Draw text by calling into the plugin:
-            rc += PsychPluginDrawText(ctx, *xp, winRec->clientrect[kPsychBottom] - myyp, stringLengthChars, textUniDoubleString);
+            rc += PsychPluginDrawText(ctx, *xp, myyp, stringLengthChars, textUniDoubleString);
         }
 
         // Restore alpha-blending settings if needed:
@@ -2206,7 +2206,6 @@ PsychError PsychDrawUnicodeText(PsychWindowRecordType* winRec, PsychRectType* bo
             if (PsychPluginGetTextCursor) {
                 // Plugin provides accurate text cursor measurement - use it:
                 PsychPluginGetTextCursor(ctx, xp, yp, theight);
-                *yp = winRec->clientrect[kPsychBottom] - *yp;
                 if (!yPositionIsBaseline)
                     *yp = *yp - ymax;
             }

--- a/Psychtoolbox/PsychBasic/DrawFormattedText.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText.m
@@ -126,6 +126,7 @@ function [nx, ny, textbounds] = DrawFormattedText(win, tstring, sx, sy, color, w
 % 02/16/16  Improve bounding box calculations for multi-line text, esp. for vSpacing > 1. (MK)
 % 03/29/16  Add sx='centerblock', always use yPosIsBaseline, update help text. (MK)
 % 08/24/16  Made vertical flip work when using FTGL plugin. (DCN)
+% 08/30/16  Fix for vertical flip is now in FTGL plugin. (DCN)
 
 % Set ptb_drawformattedtext_disableClipping to 1 if text clipping should be disabled:
 global ptb_drawformattedtext_disableClipping;
@@ -444,13 +445,6 @@ while ~isempty(tstring)
 
             textbox = OffsetRect(bbox, xp, yp);
             [xc, yc] = RectCenterd(textbox);
-            % FTGL plugin uses coordinate system with origin at bottom-left
-            % instead of PTB's top-left. Remap vertical center if doing
-            % vertical flips
-            if flipVertical && Screen('Preference', 'TextRenderer')
-                wRect = Screen('Rect', win);        % must get true height of window, not rect possibly provided by user
-                yc    = wRect(4)-yc;
-            end
 
             % Make a backup copy of the current transformation matrix for later
             % use/restoration of default state:


### PR DESCRIPTION
The FTGL plugin internally uses a coordinate system with origin at bottom-left instead of top-left. We thus have to remap the position we flip the text around.

Resolves #349 (but keep that open as there is a deeper issue that at some point should be addressed).