### PR TITLE
replaced deprecated nargchk with narginchk

### DIFF
--- a/Psychtoolbox/PsychOneliners/Ellipse.m
+++ b/Psychtoolbox/PsychOneliners/Ellipse.m
@@ -9,7 +9,7 @@ function bool = Ellipse(a,b,horpow,verpow)
 % geometric formula (x./a).^power + (y./b).^power < 1
 %
 % Ellipse(a,b,horpow,verpow) generates a generalized superEllipse according
-% to the geometric formula(x./a).^horpow + (y./b).^verpow < 1
+% to the geometric formula (x./a).^horpow + (y./b).^verpow < 1
 %
 % For more info on superEllipses, see
 %   http://en.wikipedia.org/wiki/SuperEllipse
@@ -21,8 +21,9 @@ function bool = Ellipse(a,b,horpow,verpow)
 % DN 2009-02-02 Updated to do Circles and input argument handling more
 %               efficiently
 % DN 2011-08-31 Output wasn't always of right size (ceil(2*input))
+% DN 2016-08-25 Switched from deprecated nargchk to narginchk
 
-error(nargchk(1, 4, nargin, 'struct'));
+narginchk(1,4);
 
 if nargin < 2
     b = a;

--- a/Psychtoolbox/PsychOneliners/Replace.m
+++ b/Psychtoolbox/PsychOneliners/Replace.m
@@ -34,8 +34,9 @@ function [A, tf] = Replace(A, S1, S2)
 % 1.3 (oct 2006) fixed error when using matrices
 % 1.4 (dec 2006) added additional outputs of TF and LOC
 % 1.5 (apr 2008) DN: optimized for R2007b
+% 1.6 (aug 2016) DN: Switched from deprecated nargchk to narginchk
 
-error(nargchk(3,3,nargin)) ;
+narginchk(3,3);
 
 % all three inputs should be cell arrays or numerical arrays
 if ~isequal(iscell(A), iscell(S1), iscell(S2)),

--- a/Psychtoolbox/PsychProbability/RandLim.m
+++ b/Psychtoolbox/PsychProbability/RandLim.m
@@ -13,8 +13,9 @@ function out = RandLim(n,lower,upper)
 
 % DN 2008-07-21 Wrote it
 % DN 2008-09-19 Support for vector lower and upper limits
+% DN 2016-08-25 Switched from deprecated nargchk to narginchk
 
-error(nargchk(3, 3, nargin, 'struct'))
+narginchk(3,3);
 
 r = rand(n);
 if (~isscalar(lower) && any(size(lower)~=size(r))) || (~isscalar(upper) && any(size(upper)~=size(r)))


### PR DESCRIPTION
nargchk is deprecated in current matlabs, meaning you get a warning every time you use it.
Replaced with narginchk, which is supported since R2011b and also supported on Octave.
Tested on Octave as well.
Editing also added some empty newlines at ends of files that didn't have them, but that's good practice anyway.