### PR TITLE
the line height returned by OGFLT was bogus, as it was based on unsca…

### DIFF
--- a/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
+++ b/PsychSourceGL/Cohorts/FTGLTextRenderer/libptbdrawtext_ftgl.cpp
@@ -510,10 +510,13 @@ void PsychGetTextCursor(int context, double* xp, double* yp, double* height)
 
     // Try to get line height of font:
     if (fi) {
-        if (fi->faceT)
-            *height = fi->faceT->height();
-        else
-            *height = fi->faceM->height();
+        // an OGLFT face's height() function uses the font height in the
+        // font's design units (perhaps a bug?). We need the font height
+        // scaled for the current character size display resolution.
+        // These are provided to FreeType during the FTGL face's
+        // constructor execution. We can directly access the scaled font
+        // info from the underlying FT_FACE.
+        *height = fi->ft_face->size->metrics.height / 64.;
     }
     else {
         *height = 0;


### PR DESCRIPTION
…led font heights in the font's design units. As such, it for instance did not change as the font size changed. Instead, we can get the scaled version of the text design height directly from the FT_FACE (as per subsection b of https://www.freetype.org/freetype2/docs/tutorial/step2.html#section-3). (suggested) line height in pixels is what we need for proper line spacing