### PR TITLE
Additional output arguments for cone fundamental functions

### DIFF
--- a/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
@@ -142,6 +142,7 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % 02/08/16 dhb, ms  Add lambdaMaxShift argument.
 %          ms   Don't do two way check when lambdaMax is shifted.
 % 02/24/16 dhb, ms  Started to implement Asano et al. individual difference model
+% 3/30/17  ms   Added output argument returning adjusted ind differences
 
 %% Are we doing rods rather than cones?
 if (nargin < 8 || isempty(DORODS))

--- a/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
@@ -92,9 +92,9 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % The adjIndDiffParams output argument is a struct which is populated by ComputeRawConeFundamentals.
 % It contains the actual parameter values for the parameters adjusted using the indDiffParams 
 % input. It contains the following fields:
-%    adjIndDiffParams.mac - the adjusted macular pigment density as a function of wavelength
+%    adjIndDiffParams.mac - the adjusted macular pigment transmittance as a function of wavelength
 %                           as calculated in line 151 of ComputeRawConeFundamentals.
-%    adjIndDiffParams.lens - the adjusted lens density as a function of wavelength as calculated
+%    adjIndDiffParams.lens - the adjusted lens transmittance as a function of wavelength as calculated
 %                            in line 41 of ComputeRawConeFundamentals.
 %    adjIndDiffParams.dphotopigment - 3-vector of the adjusted photopigment axial density for
 %                                     L, M and S cones (in that order), as calculated in lines

--- a/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
@@ -1,6 +1,6 @@
 function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,lambdaMax,whichNomogram,LserWeight, ...
     DORODS,rodAxialDensity,fractionPigmentBleached,indDiffParams)
-% [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,[lambdaMax],[whichNomogram],[LserWeight], ...
+% [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,[lambdaMax],[whichNomogram],[LserWeight], ...
 %   [DORODS],[rodAxialDensity],[fractionPigmentBleached],indDiffParams)
 %
 % Function to compute normalized cone quantal sensitivities
@@ -64,7 +64,7 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % for LserWeight is 0.56.  After travelling it for a distance to try to get better
 % agreement between the nomogram based fundamentals and the tabulated fundamentals
 % I (DHB) gave up and decided that using a single lambdaMax is as good as anything
-% else I could come up with. If you are interested, see FitConeFundametnalsTest.
+% else I could come up with. If you are interested, see FitConeFundamentalsTest.
 %
 % NOTE 1: When we first implemented the CIE standard, adding this shifting feature
 % seemed like a good idea to allow exploration of individual differences in photopigments.
@@ -89,6 +89,20 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % obtained them.  To do this, pass argument lambdaMaxShift with the same
 % number of entries as the number of absorbances that are used.
 %
+% The adjIndDiffParams output argument is a struct which is populated by ComputeRawConeFundamentals.
+% It contains the actual parameter values for the parameters adjusted using the indDiffParams 
+% input. It contains the following fields:
+%    adjIndDiffParams.mac - the adjusted macular pigment density as a function of wavelength
+%                           as calculated in line 151 of ComputeRawConeFundamentals.
+%    adjIndDiffParams.lens - the adjusted lens density as a function of wavelength as calculated
+%                            in line 41 of ComputeRawConeFundamentals.
+%    adjIndDiffParams.dphotopigment - 3-vector of the adjusted photopigment axial density for
+%                                     L, M and S cones (in that order), as calculated in lines
+%                                     200-202 of ComputeRawConeFundamentals.
+%
+% For both adjIndDiffParams.mac and adjIndDiffParams.lens, the wavelength spacing is the same
+% as in the S input variable of this function.
+%
 % This function also has an option to compute rod spectral sensitivities, using
 % the pre-retinal values that come from the CIE standard.  Set DORODS to true on
 % call.  You then need to explicitly pass a single lambdaMax value.  You can
@@ -102,7 +116,7 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 %
 % Finally, you can adjust the returned spectral sensitivities to account for
 % the possibility that some of the pigment in the cones is bleached.  Pass
-% a column vector with same length as number of spectral sensitivities being
+% a column vector with same length as number of spectral sensitivities beingt
 % computed.  You need to estimate the fraction elsewhere.
 %
 % Relevant to individual differences, S & S (2000) estimate the wavelength difference

--- a/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeCIEConeFundamentals.m
@@ -1,4 +1,4 @@
-function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,lambdaMax,whichNomogram,LserWeight, ...
+function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,lambdaMax,whichNomogram,LserWeight, ...
     DORODS,rodAxialDensity,fractionPigmentBleached,indDiffParams)
 % [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeCIEConeFundamentals(S,fieldSizeDegrees,ageInYears,pupilDiameterMM,[lambdaMax],[whichNomogram],[LserWeight], ...
 %   [DORODS],[rodAxialDensity],[fractionPigmentBleached],indDiffParams)
@@ -72,7 +72,7 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % spectral sensitivities, and this is not so good.  We are phasing out our
 % use of this feature in favor of simply shifting the tabulated
 % photopigment absorbances, and indeed in favor of adopting the method
-% published by Asano, Fairchild, & Blondé (2016), PLOS One, doi: 10.1371/journal.pone.0145671
+% published by Asano, Fairchild, & BlondÃˆ (2016), PLOS One, doi: 10.1371/journal.pone.0145671
 % to tailor the CIE fundamentals to individual observers.  This is done by
 % passing the argument indDiffParams, which is a structure as follows.
 %     'linear' gets the Asano et al. behavior
@@ -261,7 +261,7 @@ end
 %
 % See comment in ComputeRawConeFundamentals about the fact that
 % we ought to unify this routine and what FillInPhotoreceptors does.
-[T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeRawConeFundamentals(params,staticParams);
+[T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeRawConeFundamentals(params,staticParams);
 
 %% A little reality check.
 %
@@ -281,4 +281,3 @@ if (CHECK_FOR_AGREEMENT)
 end
 
 end
-

--- a/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
@@ -67,6 +67,9 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % See ComputeCIEConeFundamentals for the breakdown of how the Asano et al.
 % (2016) individual differences model is specified in params.indDiffParams.
 %
+% See ComputeCIEConeFundamentals for documentation of the adjIndDiffParams
+% output argument.
+%
 % See also: ComputeCIEConeFundamentals, CIEConeFundamentalsTest,
 % FitConeFundamentalsWithNomogram,
 %           FitConeFundamentalsTest, DefaultPhotoreceptors,

--- a/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
@@ -1,5 +1,5 @@
-function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeRawConeFundamentals(params,staticParams)
-% [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations] = ComputeRawConeFundamentals(params,staticParams)
+function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeRawConeFundamentals(params,staticParams)
+% [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomerizations,adjIndDiffParams] = ComputeRawConeFundamentals(params,staticParams)
 %
 % Function to compute normalized cone quantal sensitivities from underlying
 % pieces and parameters.
@@ -241,4 +241,7 @@ for i = 1:size(T_quantalAbsorptions,1)
     T_quantalAbsorptionsNormalized(i,:) = T_quantalAbsorptions(i,:)/max(T_quantalAbsorptions(i,:));
 end
 
-
+% Gather data for adjIndDiffParams
+adjIndDiffParams.mac = mac;
+adjIndDiffParams.lens = lens;
+adjIndDiffParams.dphotopigment = [LDensity MDensity SDensity];

--- a/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
+++ b/Psychtoolbox/PsychColorimetricData/ComputeRawConeFundamentals.m
@@ -78,7 +78,8 @@ function [T_quantalAbsorptionsNormalized,T_quantalAbsorptions,T_quantalIsomeriza
 % 8/12/11  dhb  Starting to make this actually work.
 % 8/14/11  dhb  Change name, expand comments.
 % 8/10/13  dhb  Expand comments.  Return unscaled quantal efficiencies too.
-% 2/26/16  dhb, ms  Add in Asano et al. (2016) individual observer adjustments.
+% 2/26/16  dhb, ms  Add in Asano et al. (2016) individual observer adjustments
+% 3/30/17  ms   Added output argument returning adjusted ind differences
 
 % Handle bad value
 index = find(params.axialDensity <= 0.0001);

--- a/Psychtoolbox/PsychTests/CIEConeFundamentalsTest.m
+++ b/Psychtoolbox/PsychTests/CIEConeFundamentalsTest.m
@@ -15,17 +15,18 @@
 % StockmanSharpeNomogram.m.
 %
 % The code here is closely related (and uses) a more general set of code
-% for setting parameters for photoreceptors and computing quantal 
+% for setting parameters for photoreceptors and computing quantal
 % sensitivities. See:
 %    DefaultPhotoreceptors, FillInPhotoreceptors, PrintPhotoreceptors,IsomerizationsInDishDemo
 %    IsomerizationsInEyeDemo, ComputeCIEConeFundamentals,
-%    ComputeRawConeFundamentals, CIEConeFundamentalsFieldSizeTEst.
+%    ComputeRawConeFundamentals, CIEConeFundamentalsFieldSizeTest.
 %
 % 8/11/11  dhb  Wrote it
 % 8/14/11  dhb  Clean up a little.
 % 12/16/12 dhb  Added test for rods.
 % 08/10/13 dhb  Better integration with the photoreceptor struct code.
 % 03/14/14 dhb  Add Smith-Pokorny to 2 degree plot, for comparison.
+% 3/31/17  ms   Added documentation of the adjIndDiffParams output args.
 
 %% Clear
 clear; close all;
@@ -217,7 +218,7 @@ if (DUMPFIGURES)
     end
 end
 
-%% Generate a rod spectral sensitivity and compare with the CIE 1951 
+%% Generate a rod spectral sensitivity and compare with the CIE 1951
 % rod spectral sensitivities
 %
 % The agreement will depend on rodLambdaMax, rodAxialDensity, and the
@@ -241,4 +242,38 @@ title('Rod fundamentals (blk), constructed (red)');
 ylabel('Normalized quantal sensitivity');
 xlabel('Wavelength');
 
+%% Test if the adjusted individual difference parameters get returned properly
+indDiffParams.dlens = 0;
+indDiffParams.dmac = 0;
+indDiffParams.dphotopigment = [0 0 0];
+indDiffParams.lambdaMaxShift = [];
+[~,~,~,adjIndDiffParamsNoChange] = ComputeCIEConeFundamentals(S,10,32,5,[], [], [], false,[],[],indDiffParams);
 
+% Change all parameters by some amount
+indDiffParamsNew.dlens = 2;
+indDiffParamsNew.dmac = -5;
+indDiffParamsNew.dphotopigment = [5 3 -4];
+indDiffParamsNew.lambdaMaxShift = [];
+[~,~,~,adjIndDiffParamsNew] = ComputeCIEConeFundamentals(S,10,32,5,[], [], [], false,[],[],indDiffParamsNew);
+
+% Calculate if they are in agreement
+fprintf('* Checking for individual difference adjustment\n');
+fprintf('> Lens density\n');
+fprintf('\tInput: \t%.2f%s\n', indDiffParamsNew.dlens, '%');
+fprintf('\tOutput: %.2f%s\n', (max(log10(adjIndDiffParamsNew.lens) ./ log10(adjIndDiffParamsNoChange.lens))-1)*100, '%');
+
+fprintf('> Macular pigment density\n');
+fprintf('\tInput: \t%.2f%s\n', indDiffParamsNew.dmac, '%');
+fprintf('\tOutput: %.2f%s\n', (max(log10(adjIndDiffParamsNew.mac) ./ log10(adjIndDiffParamsNoChange.mac))-1)*100, '%');
+
+fprintf('> L photopigment density\n');
+fprintf('\tInput: \t%.2f%s\n', indDiffParamsNew.dphotopigment(1), '%');
+fprintf('\tOutput: %.2f%s\n', ((adjIndDiffParamsNew.dphotopigment(1)/adjIndDiffParamsNoChange.dphotopigment(1))-1)*100, '%');
+
+fprintf('> M photopigment density\n');
+fprintf('\tInput: \t%.2f%s\n', indDiffParamsNew.dphotopigment(2), '%');
+fprintf('\tOutput: %.2f%s\n', ((adjIndDiffParamsNew.dphotopigment(2)/adjIndDiffParamsNoChange.dphotopigment(2))-1)*100, '%');
+
+fprintf('> S photopigment density\n');
+fprintf('\tInput: \t%.2f%s\n', indDiffParamsNew.dphotopigment(3), '%');
+fprintf('\tOutput: %.2f%s\n', ((adjIndDiffParamsNew.dphotopigment(3)/adjIndDiffParamsNoChange.dphotopigment(3))-1)*100, '%');


### PR DESCRIPTION
These two commits make `ComputeCIEConeFundamentals` and `ComputeRawConeFundamentals` return the actual parameter values that the 'individual difference adjustment' provides (e.g. lens density would be returned as a density instead of the percentage-wise parametrization provided in the input)