### PR TITLE
Added NTP synchronization to NetStation.m (including GetNTP.m, a simp…

### DIFF
--- a/Psychtoolbox/PsychHardware/Contents.m
+++ b/Psychtoolbox/PsychHardware/Contents.m
@@ -30,6 +30,7 @@
 % GetGamepadIndices   - All: Get indices of gampads in PsychHID device list.
 % GetKeyboardIndices  - All: Get indices of keyboards in PsychHID device list.
 % GetMouseIndices     - All: Get indices of mice in the PsychHID device list.
+% GetNTP              - All: Query time from NTP server.
 % OptiCAL             - All: Interface to the CRS OptiCAL luminance meter device.
 % PsychGPURasterizerOffsets - All: Test GPU drivers for spatial misplacement of content.
 % PsychGPUTestAndTweakGammaTables - All: Helper function. Auto-tweak gamma tables for DataPixx et al. and Bits#

--- a/Psychtoolbox/PsychHardware/GetNTP.m
+++ b/Psychtoolbox/PsychHardware/GetNTP.m
@@ -1,0 +1,131 @@
+function [ out ] = GetNTP( com, arg, dbg )
+% GetNTP - Query time from NTP server
+% 
+% socket = GetNTP( 'open', 'hostname' )
+% pkg = GetNTP( 'read', socket[, dbg ] )
+% GetNTP( 'close', socket )
+%
+% GetNTP is a very simple pnet based NTP client to query time from an NTP
+% server over the network.
+%
+% A pnet socket has to be created with the open command first. The read
+% command returns a structure with the fields timestamps, delay and rtt.
+% pkg.timestamps is a vector of four timestamps reflecting client send
+% time, server receive time, server transmit time, and client receive time.
+% pkg.delay is the network delay as specified by the NTP specification.
+% pkg.rtt is the round-trip-time.
+%
+% If dbg is true the NTP header is decoded completely and added to the
+% returned structure including the NTP server's reference timestamp for
+% debugging. Additionally server receive and transmit timestamps are
+% printed to the console in human readable format.
+% 
+% Note that any argument checking and error handling was omitted
+% intentionally to improve timing with NetStation synchronization.
+%
+% Reference: Mills, D. L. (2006). Network Time Protocol Version 4
+% Reference and Implementation Guide. Retrieved May 21, 2017 from
+% https://www.eecis.udel.edu/~mills/database/reports/ntp4/ntp4.pdf
+%
+% Author: Andreas Widmann, University of Leipzig, 2017
+
+% History:
+% 2017-05-25 AW Written.
+% 2017-07-19 AW Reformatted help text.
+
+% Copyright (C) 2017 Andreas Widmann, University of Leipzig, widmann@uni-leipzig.de
+%
+% MIT license:
+%
+% Permission is hereby granted, free of charge, to any person obtaining a
+% copy of this software and associated documentation files (the
+% "Software"), to deal in the Software without restriction, including
+% without limitation the rights to use, copy, modify, merge, publish,
+% distribute, sublicense, and/or sell copies of the Software, and to permit
+% persons to whom the Software is furnished to do so, subject to the
+% following conditions:
+%
+% The above copyright notice and this permission notice shall be included
+% in all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+% OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+% NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+% DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+% OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+% USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+switch com
+
+    case 'open'
+        out = pnet( 'udpsocket', 3333 );
+        pnet( out, 'setreadtimeout', 1 );
+        pnet( out, 'udpconnect', arg, 123 );
+
+    case 'close'
+        pnet( arg, 'close' );
+
+    case 'read'
+        
+        % Timing sensitive
+        msg = uint8( [ 27 zeros(1, 47) ] );
+        pnet( arg, 'write', msg);
+        out.timestamps( 1 ) = GetSecs;
+        pnet( arg, 'writepacket' );
+        pkgsize = pnet( arg, 'readpacket' );
+        out.timestamps( 4 ) = GetSecs;
+        
+        % Timing insensitive
+        if pkgsize < 48
+            error( 'No NTP package received.' );
+        end
+        
+        % Header
+        lvm = pnet( arg, 'read', 1, 'uint8');
+        % Decode header only for potential KoD (LI == 3) package or on request
+        if lvm > 191 || ( nargin > 2 && dbg )
+            lvm = dec2bin( lvm, 8 );
+            out.LI = bin2dec( lvm( 1:2 ) );
+            out.VN = bin2dec( lvm( 3:5 ) );
+            out.Mode = bin2dec( lvm( 6:8 ) );
+            
+            out.stratum = pnet( arg, 'read', 1, 'uint8');
+            out.poll = pnet( arg, 'read', 1, 'int8');
+            out.prec = pnet( arg, 'read', 1, 'int8');
+            % Root delay and dispersion; signed fixed point; decoding to be implemented, possibly
+            out.root = pnet( arg, 'read', 2, 'uint32'); 
+            
+            id = pnet( arg, 'read', 4, 'uint8');
+            if out.stratum == 0 || out.stratum == 1
+                out.id = char( id );
+            else
+                out.id = sprintf( '%d.%d.%d.%d', id );
+            end
+            
+            if out.LI == 3 && out.stratum == 0
+                error( 'KoD package received. Reason: %s.', out.id );
+            end
+        else
+            pnet( arg, 'read', 15, 'uint8');
+        end
+
+        % Timestamps
+        timestamps = double( pnet( arg, 'read', 8, 'uint32') );
+        timestamps = timestamps( :, 1:2:7 ) + timestamps( :, 2:2:8 ) / 2 ^ 32;
+        
+        % Receive and transmit timestamps
+        out.timestamps( 2:3 ) = timestamps( 3:4 );
+        out.delay = ( out.timestamps( 4 ) - out.timestamps( 1 ) ) - ( out.timestamps( 3 ) - out.timestamps( 2 ) );
+        out.rtt = out.timestamps( 4 ) - out.timestamps( 1 );
+
+        if nargin > 2 && dbg
+            % Reference timestamp
+            out.reference = timestamps( 1 ); 
+            for iTimestamp = 2:3
+                % From modified NetStation.m by Justin and Mario:
+                matlabDateNum = datenum( [ 1900 1 1 0 0 out.timestamps( iTimestamp ) ] );
+                datestr( matlabDateNum, 'yyyy-mm-dd HH:MM:SS.FFF' )
+            end
+        end
+end


### PR DESCRIPTION
This patch adds NTP based event synchronization to NetStation. It includes a very simple NTP client GetNTP.m.

The new NetStation 'getntpsynchronize' command implements the EGI N-type synchronization (eci_NTPClockSynch) method transmitting a self selected timestamp. Event latencies are then transmitted as difference to this timestamp.

This is so far only tested  for 400 series amps with NetStation 5.3 and Psychtoolbox on Linux by Urte Roeber.  It might possibly also work for 300 series amps (using the NetStation PC as NTP server) and other NetStation software versions and OS but would require testing.

The implemented solution does NOT depend on NTP synchronized clocks between the NetStation (amp) and Psychtoolbox machines (as millisecond precision cannot be achieved without reliable external clock source). Rather the current NTP server (i.e. amp) time is queried at event time using the GetNTP client. Event latency is computed in server time as difference between the synchronization timestamp and the NTP timestamp requested at event time. Client time and clock sync do not matter.

If the observed network delay exceeds 2 ms a new timestamp is requested (up to 4 times; never exceeded one time in any of the tests). Event latency is corrected by half the observed NTP network delay (thus timing uncertainty is max. 1 ms) and the delay between event time and NTP request transmission time (in client time; corrected by the clock drift estimated by regression on the basis of the preceding NTP packages).

We intensively tested the solution with audio and video (photodiode) and the EGI AV tester box. Precision was in an approximately -/+0.5 ms range without exception in several thousands of trials and, thus, about 5 times more precise compared to our tests with the existing solution.

Apart from NTP synchronization only some minor cleaning (replaced returns in nested functions by ends) was done and the NetStation.m function is expected to be fully backward compatible.

For future reference:
(a) It is essential to use zero for the fraction of seconds part of the synchronization timestamp. Drift and offset are observed otherwise. Presumably, this is due to improper handling of the fraction of seconds part by the EGI NetStation software.
(b) The alternative S-type synchronization method (relative to amp start time) is broken in several ways: In response to an S-type synchronization request not amp start time but current amp time is received. Thus, amp start time has to be entered manually. The received NTP timestamp's fraction of seconds part is in microsecond and not in fractions of 2^32 as expected. The actual protocol differs from documentation. Finally, the NetStation software does not use amp start time for synchronization internally but some other timestamp, presumably the time of synchronization request. As this timestamp includes (uncontrolled) network delays it might introduce timing jitter between sessions or blocks. This was also practically observed while testing.

Both only applies to the tested NetStation 5.3.0.1 software and might be different in older or future version. The applied zero in fraction of seconds workaround should not hurt in future versions (if the protocol is not finally messed up).