### PR TITLE
makeftglplugin: display return of system call before movefile.

### DIFF
--- a/PsychSourceGL/Cohorts/FTGLTextRenderer/makeftglplugin.m
+++ b/PsychSourceGL/Cohorts/FTGLTextRenderer/makeftglplugin.m
@@ -43,12 +43,11 @@ end
 
 if ~isempty(cmd)
     [rc, ret] = system(cmd);
+    disp(ret);
     if rc == 0
         movefile(name, [PsychtoolboxRoot 'PsychBasic' filesep 'PsychPlugins']);
-        disp(ret);
         fprintf('Success.\n');
     else
-        disp(ret);
         fprintf('FAILED!\n');
     end
 end


### PR DESCRIPTION
Because if system call contains a failure, but is run via bat file which itself completed successfully (i.e., the Windows build setup), we never see the output from the build as movefile fails.