### PR TITLE
Update Contents.m

### DIFF
--- a/Psychtoolbox/PsychColorimetricData/PsychColorimetricMatFiles/Contents.m
+++ b/Psychtoolbox/PsychColorimetricData/PsychColorimetricMatFiles/Contents.m
@@ -75,7 +75,7 @@
 %   spd_CIEC            - Spectral power distribution for CIE illuminant C.
 %   spd_D65             - Spectral power distribution for CIE illuminant D65.
 %   spd_flourescent     - Spectral power distribution for some flourescent lamp.
-%   spd_incanCC         - Spectral power distribution for some incandescent lamp.
+%   spd_incanCC         - Spectral power distributions for Macbeth color checker patches under some incandescent lamp.
 %   spd_phillybright    - Direct bright sunlight measured through window and off of a piece of white paper towel
 %                       -   on the floor of DB's office in Philly, March 2013.
 %                       -   Measurements made with PR-650, power in Watts/[m2-sr-wlband].


### PR DESCRIPTION
`spd_incanCC` is size 81, 24 and appears to be the Macbeth color checker seen under some incandescent lamp. `spd_incanCC ./ sur_macbeth` (with `sur_macbeth` from this folder as well) yields a broadband incandescent illuminant spd.