### PR TITLE
AddXXXToGLOperator: Add workaround for empty rects in gloperator's.

### DIFF
--- a/Psychtoolbox/PsychGLImageProcessing/Add2DConvolutionToGLOperator.m
+++ b/Psychtoolbox/PsychGLImageProcessing/Add2DConvolutionToGLOperator.m
@@ -60,6 +60,7 @@ end
 
 % Switch to gloperators OpenGL context:
 Screen('GetWindowInfo', gloperator);
+while glGetError(); end;
 
 % Transpose kernel to make sure we follow the strict definition of
 % convolution and stay compatible with Matlab/Octave:

--- a/Psychtoolbox/PsychGLImageProcessing/Add2DSeparableConvolutionToGLOperator.m
+++ b/Psychtoolbox/PsychGLImageProcessing/Add2DSeparableConvolutionToGLOperator.m
@@ -105,6 +105,7 @@ end
 
 % Switch to gloperators OpenGL context:
 Screen('GetWindowInfo', gloperator);
+while glGetError(); end;
 
 % Input parsing done. Call helper routine for creation of shaders and
 % optional lookup textures:

--- a/Psychtoolbox/PsychGLImageProcessing/AddImageUndistortionToGLOperator.m
+++ b/Psychtoolbox/PsychGLImageProcessing/AddImageUndistortionToGLOperator.m
@@ -73,6 +73,7 @@ end
 
 % Switch to gloperators OpenGL context:
 Screen('GetWindowInfo', gloperator);
+while glGetError(); end;
 
 % Make sure gloperator is enabled for imaging operations:
 Screen('HookFunction', gloperator, 'ImagingMode', mor(kPsychNeedFastBackingStore, Screen('HookFunction', gloperator, 'ImagingMode')));

--- a/Psychtoolbox/PsychGLImageProcessing/AddImageWarpToGLOperator.m
+++ b/Psychtoolbox/PsychGLImageProcessing/AddImageWarpToGLOperator.m
@@ -17,6 +17,7 @@ end
 
 % Switch to gloperators OpenGL context:
 Screen('GetWindowInfo', gloperator);
+while glGetError(); end;
 
 % Make sure gloperator is enabled for imaging operations:
 Screen('HookFunction', gloperator, 'ImagingMode', mor(kPsychNeedFastBackingStore, Screen('HookFunction', gloperator, 'ImagingMode')));


### PR DESCRIPTION
GLOperator's are proxy windows, which get initialize to have
zero size, ie. empty [0,0,0,0] rects. This causes an OpenGL
invalid value error in gluOrtho2D() when Screen('GetWindowInfo, gloperator);
trigger PsychSetDrawingTarget -> PsychSetupView -> gluOrtho2D(0,0,0,0,1,-1).

The proper fix is to give such proxy windows at least a [0,0,1,1] rect for
a 1x1 pixel size, but that would require a full recompile for Screen()
on all platforms.

Work around this by swallowing the error via glGetError() calls.