### PR TITLE
DrawFormattedText2 enhancements

### DIFF
--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -1172,7 +1172,7 @@ switch yalign
         yoff = -bHeight;
 end
 
-bbox = OffsetRect(bbox,sx+xoff,sy+yoff);
+bbox = OffsetRect(bbox,round(sx+xoff),round(sy+yoff));
 end
 
 function bbox = transformBBox(bbox,transform)

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -439,6 +439,7 @@ lWidth          = zeros(1,numlines);
 lWidthOff       = zeros(2,numlines);
 lBaseLineSkip   = zeros(1,numlines);
 lBaseLineOff    = zeros(2,numlines);
+lWidthOffLine   = zeros(3,length(subStrings));
 sWidth          = zeros(1,length(subStrings));
 px              = zeros(1,length(subStrings));
 py              = zeros(1,length(subStrings));
@@ -456,7 +457,6 @@ for p=1:numlines
     
     % to get line width and height, get textbounds of each string and add
     % them together
-    lWidthOffLine = zeros(3,length(qSubStr));
     for q=find(qSubStr)
         % do format change if needed
         if any(switches(:,q))

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -470,7 +470,7 @@ for p=1:numlines
             DoFormatChange(win,switches(:,q),fmt);
         end
         if isempty(subStrings{q})
-            [~,bbox]        = Screen('TextBounds', win,           'x',0,0,1,righttoleft);
+            [~,bbox,h]      = Screen('TextBounds', win,           'x',0,0,1,righttoleft);
             xAdv = 0;
         else
             [~,bbox,h,xAdv] = Screen('TextBounds', win, subStrings{q},0,0,1,righttoleft);

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -1264,7 +1264,7 @@ function [opt,qCalledWithCache] = parseInputs(varargs,nOutArg)
 
 if isempty(varargs) || isempty(varargs{1})
     % Empty text string -> Nothing to do.
-    opt                 = struct();
+    opt                 = [];
     qCalledWithCache    = false;
     return;
 elseif isstruct(varargs{1})

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -347,7 +347,11 @@ end
 [tstring,fmtCombs,fmts,switches,previous] = getFormatting(win,char(tstring),baseColor,resetStyle);
 % check we still have anything to render after formatting tags removed
 if isempty(tstring)
-    % Empty text string -> Nothing to do.
+    % Empty text string -> Nothing to do, but assign dummy values:
+    [nx, ny]    = Screen('DrawText', win, '');
+    textbounds  = [nx, ny, nx, ny];
+    wordbounds  = textbounds;
+    cache       = [];
     return;
 end
 
@@ -1039,6 +1043,12 @@ codes.style(toStrip) = [];
 codes.color(toStrip) = [];
 codes.font (toStrip) = [];
 codes.size (toStrip) = [];
+
+if isempty(tstring)
+    % strong was only formatting commands, nothing to draw, ignore
+    [fmtCombs,fmts,switches,previous] = deal([]);
+    return;
+end
 
 % process colors, hex->dec
 for p=1:length(tables.color)

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -344,7 +344,7 @@ end
 
 % string can contain HTML-like formatting commands. Parse them and turn
 % them into formatting indicators, then remove them from the string to draw
-[tstring,fmtCombs,fmts,switches,previous] = getFormatting(win,tstring,baseColor,resetStyle);
+[tstring,fmtCombs,fmts,switches,previous] = getFormatting(win,char(tstring),baseColor,resetStyle);
 % check we still have anything to render after formatting tags removed
 if isempty(tstring)
     % Empty text string -> Nothing to do.

--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -4,7 +4,7 @@ function [nx, ny, textbounds, cache, wordbounds] = DrawFormattedText2(varargin)
 % [nx, ny, textbounds, cache, wordbounds] = DrawFormattedText2(cache, key-value pairs)
 % 
 % When called with a string, the following key-value pairs are understood:
-% win [, sx][, sy][, xalign][, yalign][, xlayout][, color][, wrapat][, transform][, vSpacing][, righttoleft][, winRect][, resetStyle][, cacheOnly]
+% win [, sx][, sy][, xalign][, yalign][, xlayout][, baseColor][, wrapat][, transform][, vSpacing][, righttoleft][, winRect][, resetStyle][, cacheOnly]
 % Those enclosed in square braces are optional.
 % 
 % When called with a cache struct, the following optional key-value pair
@@ -1352,6 +1352,8 @@ else
     % Keep current text color if none provided:
     if isempty(opt.baseColor)
         opt.baseColor = Screen('TextColor', opt.win);
+    else
+        opt.baseColor = opt.baseColor(:).'; % ensure row vector
     end
     
     % No text wrapping by default:

--- a/Psychtoolbox/PsychDemos/DrawFormattedText2Demo.m
+++ b/Psychtoolbox/PsychDemos/DrawFormattedText2Demo.m
@@ -51,22 +51,38 @@ try
 
     Screen('Flip',w);
     KbStrokeWait;
+    
+    % unicode text, see DrawHighQualityUnicodeTextDemo for more info about
+    % how to draw unicode text
+    unicodetext = [26085, 26412, 35486, 60, 99, 111, 108, 111, 114, 62, ...
+        12391, 12354, 12426, 12364, 12392, 12358, 12372, 12374, 12356, ...
+        12414, 12375, 12383, 12290, 13, 10];
+    [~,~,~,~,wbounds] = DrawFormattedText2([double('<size=40><font=-:lang=ja><color=ff0000>') unicodetext],'win',w,'sx','center','sy','center','xalign','center','yalign','center');
+    % Screen('FrameRect', w, [255 255 0], wbounds.');
+    
+    Screen('Flip',w);
+    KbStrokeWait;
 
     % draw few lines of text, with varying formatting, and draw it again
     % from cache with some transformation
     [~,~,bbox,cache,wbounds]=DrawFormattedText2('<font=Courier New><size=27>test\n<font=Times New Roman>scr<font><font>een<font> is\n<b><size=50>UGLY\n<size=12><b><u><i>Isn''t it?','win',w,'sx','center','sy','center','xalign','center','yalign','center');
-    Screen('FrameRect', w, [255 0 0], bbox);
-    Screen('FrameRect', w, [255 255 0], GrowRect(wbounds, 2, 2)');
+    Screen('FrameRect', w, [255 0 0 100], bbox);
+    % captbbox = bbox;
+    Screen('FrameRect', w, [255 255 0], wbounds.');
     % calling with the cache and only sx and/or sy, translated the text by
     % (sx,sy)
-    [~,~,bbox]=DrawFormattedText2(cache,'sx', 300);
+    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sx', 300);
     Screen('FrameRect', w, [0 255 0], bbox);
-    [~,~,bbox]=DrawFormattedText2(cache,'sx',-300,'transform',{'flip',1});
+    Screen('FrameRect', w, [255 255 0], wbounds.');
+    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sx',-300,'transform',{'flip',1});
     Screen('FrameRect', w, [0 0 255], bbox);
-    [~,~,bbox]=DrawFormattedText2(cache,'sy', 300,'transform',{'rotate',90});
+    Screen('FrameRect', w, [255 255 0], wbounds.');
+    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sy', 300,'transform',{'rotate',90});
     Screen('FrameRect', w, [0 255 255], bbox);
-    [~,~,bbox]=DrawFormattedText2(cache,'sy',-300,'transform',{'scale',[2 1]});
+    Screen('FrameRect', w, [255 255 0], wbounds.');
+    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sy',-300,'transform',{'scale',[2 1]});
     Screen('FrameRect', w, [255 0 255], bbox);
+    Screen('FrameRect', w, [255 255 0], wbounds.');
     % when called with more alignment inputs, the bounding box of the text
     % is repositioned:
     rect = [100 100 350 250];
@@ -80,34 +96,15 @@ try
     DrawFormattedText2('simple\ntest\ntext','win',w,'sx','right','sy','bottom','xalign','left','yalign','bottom','winRect',rect,'vSpacing',1.5);
     
     Screen('Flip',w);
-    KbStrokeWait;
-
-    % Repeat, but visualize word-bounds:
-    % calling with the cache and only sx and/or sy, translated the text by
-    % (sx,sy)
-    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'transform',{'flip',3});
-    Screen('FrameRect', w, [255 255 0 128], GrowRect(wbounds, 2, 2)');
-    Screen('FrameRect', w, [0 255 0], bbox);
-    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sx', 300,'transform',{'flip',2});
-    Screen('FrameRect', w, [255 255 0 128], GrowRect(wbounds, 2, 2)');
-    Screen('FrameRect', w, [0 255 0], bbox);
-    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sx',-300,'transform',{'flip',1});
-    Screen('FrameRect', w, [255 255 0 128], GrowRect(wbounds, 2, 2)');
-    Screen('FrameRect', w, [0 0 255], bbox);
-    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sy', 300,'transform',{'rotate',90});
-    Screen('FrameRect', w, [255 255 0 128], GrowRect(wbounds, 2, 2)');
-    Screen('FrameRect', w, [0 255 255], bbox);
-    [~,~,bbox,~,wbounds]=DrawFormattedText2(cache,'sy',-300,'transform',{'scale',[2 1]});
-    Screen('FrameRect', w, [255 255 0 128], GrowRect(wbounds, 2, 2)');
-    Screen('FrameRect', w, [255 0 255], bbox);
-
-    Screen('Flip',w);
+    % capt = Screen('GetImage', w, GrowRect(captbbox,20,20));
     KbStrokeWait;
 
     % draw some text, then draw it again in exact same location but rotated
     % 180 degrees. should have exact same bounding box
-    [~,~,bbox1,c]=DrawFormattedText2('<size=40>t<i>e<size>x<i>t&\n<size=120>ajX\n<size=60>t<font=comic sans>estddd<color=ff0000>ddda<i>d','win',w,'sx','center','sy',200,'xalign','left','baseColor',0);
+    [~,~,bbox1,c]=DrawFormattedText2('<size=40>t<i>e<size>x<i>t&\n<size=120>ajX\n<size=60>t<font=comic sans>estddd<color=ff0000>ddda<i>d','win',w,'sx','center','sy',200,'xalign','left','baseColor',0,'cacheMode',2);  % just testing cachemode 2. not recommended to be used for performance reasons. Only use if you want to manually change content of the cache, though note the cache format may change without warning
     [~,~,bbox2]  =DrawFormattedText2(c,'transform',{'rotate',180});
+    % this is equivalent to:
+    % [~,~,bbox2]  =DrawFormattedText2(c,'transform',{'flip',3});
     Screen('FrameRect',w,[255 0 0 128],bbox1,3);
     Screen('FrameRect',w,[0 255 0 128],bbox2,3);
     fprintf('Both bounding boxes exactly the same? %d\n',isequal(bbox1,bbox2));
@@ -167,3 +164,5 @@ catch me
     sca;
     rethrow(me)
 end
+
+% image(capt)

--- a/Psychtoolbox/PsychOneliners/WrapString.m
+++ b/Psychtoolbox/PsychOneliners/WrapString.m
@@ -62,6 +62,6 @@ if n>length(string)
   string='';
   return
 end
-wrapped=[wrapped string(1:n-1) sprintf('\n')];
+wrapped=[wrapped string(1:n-1) cast(10,class(tstring))];
 string=string(n+1:end);
 return


### PR DESCRIPTION
- bugfix: now works with unicode text
- now by default draws to texture as cache instead of pregens sequence of drawtext calls: much better performance, and output looks nicer too when transforming (on my setup anyway, kinda strange really).
- redid wordbounds so that it works with this new cache as well
- properly dealing with empty input string or string containing only formatting directives (both now ignored)
- some comment fixes