### PR TITLE
DrawFormattedText2: fixed baseColor parameter

### DIFF
--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -99,7 +99,7 @@ function [nx, ny, textbounds, cache, wordbounds] = DrawFormattedText2(varargin)
 % bounding box. Justification options are currently not supported.
 %
 % 'baseColor' is the color in which the text will be drawn (until changed
-% by a <color> format call. This is also the color that will remain active
+% by a <color> format call). This is also the color that will remain active
 % after invocation of this function.
 %
 % 'wrapat', if provided, will automatically break text strings longer than
@@ -1092,7 +1092,7 @@ codes.size (toStrip) = [];
 tstring = tstringOri;
 
 if isempty(tstring)
-    % strong was only formatting commands, nothing to draw, ignore
+    % string was only formatting commands, nothing to draw, ignore
     [fmtCombs,fmts,switches,previous] = deal([]);
     return;
 end
@@ -1131,10 +1131,9 @@ end
 c = [codes.style; codes.color; codes.font; codes.size];
 % where do changes occur?
 switches = logical(diff([[previous.style; 1; 1; previous.size] c],[],2));
-% if user-provided baseColor, make sure it is applied!
-if ~isnumeric(startColor)
-    switches(2,1) = true;
-end
+% make sure color is always applied, may have been changed under our feet
+% if drawn later, or may have been provided as baseColor by user
+switches(2,1) = true;
 % get unique formats and where each of these formats is to be applied
 % the below is equivalent to:
 % [format,~,fmtCombs] = unique(c.','rows');

--- a/Psychtoolbox/PsychDemos/DrawFormattedText2Demo.m
+++ b/Psychtoolbox/PsychDemos/DrawFormattedText2Demo.m
@@ -45,9 +45,12 @@ try
     DrawFormattedText2('top\ncenter','win',w,'sx','center','sy',scrY-150,'xalign','center','yalign','bottom','xlayout','center');
     DrawFormattedText2('top\nleft<color=ff0000>1','win',w,'sx',scrX-150,'sy',scrY-150,'xalign','right','yalign','bottom','xlayout','right');
     DrawFormattedText2('top\nleft<color=0.,1.,0.>2','win',w,'sx',scrX-150,'sy',scrY-150,'xalign', 'left','yalign','bottom');
-    DrawFormattedText2('center\n<b>inside','win',w,'sx','center','sy','center','xalign','center','yalign','center','xlayout','center','winRect',rect);
+    % the below call sets a new basecolor, which is a state that should
+    % leak out, setting default color from that call onward
+    DrawFormattedText2('center\n<b>inside','win',w,'sx','center','sy','center','xalign','center','yalign','center','xlayout','center','winRect',rect,'baseColor',[0 255 0]);
     DrawFormattedText2('bottom\n<i>left' ,'win',w,'sx',scrX-150,'sy',scrY+150,'xalign','right','yalign','top','xlayout','right');
-    DrawFormattedText2('bottom\n<u>right','win',w,'sx',scrX+150,'sy',scrY+150,'xalign', 'left','yalign','top');
+    % next call resets base color to black
+    DrawFormattedText2('bottom\n<u>right','win',w,'sx',scrX+150,'sy',scrY+150,'xalign', 'left','yalign','top','baseColor',0);
 
     Screen('Flip',w);
     KbStrokeWait;


### PR DESCRIPTION
base color didn't actually work (weird!). Now have a test for it, and fixed it