### PR TITLE
PKG: Include license file in Python source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include PsychSourceGL/License.txt

--- a/setup.py
+++ b/setup.py
@@ -233,6 +233,7 @@ setup (name = 'psychtoolbox',
        packages = ['psychtoolbox'],
        package_dir = {'psychtoolbox' : 'PsychPython'},
        package_data = extra_files,
+       include_package_data=True,  # Include files listed in MANIFEST.in
        ext_package= 'psychtoolbox',
        ext_modules = [WaitSecs, GetSecs, IOPort, PsychHID, PsychPortAudio]
       )


### PR DESCRIPTION
The inclusion of the license file is required e.g. when creating a package for `conda-forge`. Generally, it's always a good idea to include it. Closes #538.
