### PR TITLE
ConfirmInfo and TwoStateQuery now work in GUI mode on R2014b and later

### DIFF
--- a/Psychtoolbox/PsychHardware/Daq/Utilities/ConfirmInfo.m
+++ b/Psychtoolbox/PsychHardware/Daq/Utilities/ConfirmInfo.m
@@ -3,7 +3,7 @@ function ReturnFigh = ConfirmInfo(TheQuestion,ButtonString,HowLongToWait)
 % 
 % Purpose: Create simple dialog box asking user to verify receipt of information.
 %
-% On Octave, Matlab in non-GUI mode, or Matlab version R2014b (8.4) or later,
+% On Octave, or Matlab in non-GUI mode, 
 % this will just print 'TheQuestion' to the command window and wait for a key
 % press for confirmation. Older Matlab versions present a GUI dialog box.
 %
@@ -38,13 +38,14 @@ function ReturnFigh = ConfirmInfo(TheQuestion,ButtonString,HowLongToWait)
 %                           space does not overrun number of spaces
 %          5/20/13    mk    Add text only fallback for Octave and non-GUI.
 %          7/20/17    mk    Use text only fallback on Matlab R2014b and later.
+%          7/11/19    mk    GUI version now works on Matlab R2014b and later.
 DoModal = 1;
 if nargin < 3 || isempty(HowLongToWait)
   HowLongToWait = Inf;
 end
 
 % Provide text fallback for non-GUI mode or Octave:
-if ~IsGUI || IsOctave || ~verLessThan('matlab','8.4')
+if ~IsGUI || IsOctave
   fprintf('%s\nPress any key to continue.\n', TheQuestion);
   [secs, keyCode] = KbStrokeWait (-1, GetSecs + HowLongToWait);
   if any(keyCode)
@@ -82,8 +83,12 @@ OkayBHeight = 50;
 PrimeFontSize = 36;
 
 QueryFigh = figure('Position',[FigPos FigWidth FigHeight],'Resize','off','NumberTitle','off', ...
-									'Name','Acknowledge','Menubar','none','Color','k');
-set(QueryFigh,'Tag',['Confirmation Figure ' int2str(QueryFigh)]);
+    'Name','Acknowledge','Menubar','none','Color','k');
+QueryFighNr = QueryFigh;
+if ~isnumeric(QueryFighNr)
+    QueryFighNr = QueryFigh.Number;
+end
+set(QueryFigh,'Tag',['Confirmation Figure ' int2str(QueryFighNr)]);
 axes('Position',[0 0 1 1],'XLim',[0 FigWidth],'YLim',[0 FigHeight],'XColor','k','YColor','k');
 th=text(FigWidth/2,0.7*FigHeight,TheQuestion,'FontSize',PrimeFontSize,'Color',get_color('hot pink'), ...
 				'HorizontalAlignment','Center');
@@ -205,7 +210,7 @@ end
 OkayBh = uicontrol('Style','PushButton','Position',[OkayBPos OkayBWidth OkayBHeight],'String',ButtonString, ...
 									'ForeGroundColor',get_color('midnight blue'),'BackgroundColor', ...
 									get_color('wheat'),'FontSize',36,'Tag','OkayButton','UserData',-1);
-set(OkayBh,'CallBack',['set(findobj(' int2str(QueryFigh) ',''Tag'',''OkayButton''),''UserData'',1);']);
+set(OkayBh,'CallBack',['set(findobj(' int2str(QueryFighNr) ',''Tag'',''OkayButton''),''UserData'',1);']);
 OkayBSSize = get(OkayBh,'Extent');
 while OkayBSSize(3) > OkayBWidth
 	if OkayBPos(1)+OkayBWidth > FigWidth - OkayBWidth/2
@@ -247,10 +252,10 @@ if DoModal
 	
   UserHitOkay = ishandle(OkayBh);
   
-	delete(findobj('Tag',['Confirmation Figure ' int2str(QueryFigh)]));
+	delete(findobj('Tag',['Confirmation Figure ' int2str(QueryFighNr)]));
 else
   UserHitOkay = 1;
-	set(OkayBh,'CallBack',['delete(' int2str(QueryFigh) ');']);
+	set(OkayBh,'CallBack',['delete(' int2str(QueryFighNr) ');']);
 end
 
 if nargout

--- a/Psychtoolbox/PsychHardware/Daq/Utilities/TwoStateQuery.m
+++ b/Psychtoolbox/PsychHardware/Daq/Utilities/TwoStateQuery.m
@@ -2,8 +2,8 @@ function UserResponse = TwoStateQuery(TheQuestion,TheChoices)
 % Syntax: UserResponse = TwoStateQuery(TheQuestion,[TheChoices])
 % 
 % Purpose: Create simple dialog box asking user an either/or question.
-% On non-GUI setups or Octave, it will ask a question
-% in the command window instead of showing a GUI dialog box.
+% On non-GUI setups it will ask a question in the command window instead
+% of showing a GUI dialog box.
 %
 % History:  5/5/04   mpr   decided whether or not to celebrate cinco de mayo
 %           10/13/04 mpr   set Yes Button automatically to be enlarged for large
@@ -46,8 +46,8 @@ for k=length(UnderScoreSpots):-1:1
   TheQuestion = [TheQuestion(1:(UnderScoreSpots(k)-1)) '\' TheQuestion(UnderScoreSpots(k):end)];
 end
 
-% Provide text fallback for non-GUI mode or Octave:
-if ~IsGUI || IsOctave
+% Provide text fallback for non-GUI mode:
+if ~IsGUI
   fprintf('%s\n', TheQuestion);
   fprintf('0 = %s\n', TheChoices{2});
   fprintf('1 = %s\n', TheChoices{1});
@@ -64,9 +64,9 @@ end
 % questdlg builtin dialog box for Octave with GUI:
 if IsOctave
   button = questdlg(TheQuestion, 'Question', TheChoices{1}, TheChoices{2}, 'Cancel', 'Cancel');
-  if strcmp(button, TheChoices{1})
+  if ~isempty(strfind(button, TheChoices{1}))
     UserResponse = 1;
-  elseif strcmp(button, TheChoices{2})
+  elseif ~isempty(strfind(button, TheChoices{2}))
     UserResponse = 0;
   else
     UserResponse = -1;

--- a/Psychtoolbox/PsychHardware/Daq/Utilities/TwoStateQuery.m
+++ b/Psychtoolbox/PsychHardware/Daq/Utilities/TwoStateQuery.m
@@ -2,7 +2,7 @@ function UserResponse = TwoStateQuery(TheQuestion,TheChoices)
 % Syntax: UserResponse = TwoStateQuery(TheQuestion,[TheChoices])
 % 
 % Purpose: Create simple dialog box asking user an either/or question.
-% On non-GUI setups or Matlab R2014b or later, it will ask a question
+% On non-GUI setups or Octave, it will ask a question
 % in the command window instead of showing a GUI dialog box.
 %
 % History:  5/5/04   mpr   decided whether or not to celebrate cinco de mayo
@@ -27,7 +27,8 @@ function UserResponse = TwoStateQuery(TheQuestion,TheChoices)
 %                          fixed
 %           5/20/13  mk    Add text only fallback for Octave and non-GUI.
 %          11/05/15  mk    Add GUI dialog for Octave in GUI mode. White-space cleanup.
-%          7/20/17   mk    Use text only fallback on Matlab R2014b and later.
+%           7/20/17  mk    Use text only fallback on Matlab R2014b and later.
+%           7/11/19  dn    GUI version now works on Matlab R2014b and later.
 
 if nargin < 2 || isempty(TheChoices)
   TheChoices{1} = 'Yes';
@@ -45,8 +46,8 @@ for k=length(UnderScoreSpots):-1:1
   TheQuestion = [TheQuestion(1:(UnderScoreSpots(k)-1)) '\' TheQuestion(UnderScoreSpots(k):end)];
 end
 
-% Provide text fallback for non-GUI mode or Matlab R2014b and later:
-if ~IsGUI || (~IsOctave && ~verLessThan('matlab','8.4'))
+% Provide text fallback for non-GUI mode or Octave:
+if ~IsGUI || IsOctave
   fprintf('%s\n', TheQuestion);
   fprintf('0 = %s\n', TheChoices{2});
   fprintf('1 = %s\n', TheChoices{1});
@@ -85,7 +86,11 @@ PrimeFontSize = 36;
 
 QueryFigh = figure('Position',[FigPos FigWidth FigHeight],'Resize','off','NumberTitle','off', ...
                   'Name','Cross the Rubicon','MenuBar','none','Color','k');
-set(QueryFigh,'Tag',['Questionable Figure ' int2str(QueryFigh)]);
+QueryFighNr = QueryFigh;
+if ~isnumeric(QueryFighNr)
+    QueryFighNr = QueryFigh.Number;
+end
+set(QueryFigh,'Tag',['Questionable Figure ' int2str(QueryFighNr)]);
 axes('Position',[0 0 1 1],'XLim',[0 FigWidth],'YLim',[0 FigHeight],'XColor','k','YColor','k');
 th=text(FigWidth/2,0.65*FigHeight,TheQuestion,'FontSize',36,'Color',get_color('hot pink'), ...
         'HorizontalAlignment','Center');
@@ -108,13 +113,13 @@ end
 YesBh = uicontrol('Style','PushButton','Position',[YesBPos YesBWidth YesBHeight],'String',TheChoices{1}, ...
                   'ForeGroundColor',get_color('midnight blue'),'BackgroundColor', ...
                   get_color('wheat'),'FontSize',36,'Tag','YesButton','UserData',-1);
-set(YesBh,'CallBack',['set(findobj(' int2str(QueryFigh) ',''Tag'',''YesButton''),''UserData'',1);']);
+set(YesBh,'CallBack',['set(findobj(' int2str(QueryFighNr) ',''Tag'',''YesButton''),''UserData'',1);']);
 NoBWidth = YesBWidth;
 NoBHeight = YesBHeight; 
 NoBh = uicontrol('Style','PushButton','Position',[NoBPos YesBWidth YesBHeight],'String',TheChoices{2}, ...
                 'ForeGroundColor',get_color('midnight blue'),'BackgroundColor', ...
                 get_color('wheat'),'FontSize',36,'CallBack', ...
-                ['set(findobj(' int2str(QueryFigh) ',''Tag'',''YesButton''),''UserData'',0);']);
+                ['set(findobj(' int2str(QueryFighNr) ',''Tag'',''YesButton''),''UserData'',0);']);
 YesBSSize = get(YesBh,'Extent');
 while YesBSSize(3) > YesBWidth
   if YesBPos(1)+YesBWidth > NoBPos(1) - YesBWidth/2
@@ -151,7 +156,7 @@ drawnow;
 waitfor(YesBh,'UserData');
 
 % just in case user deletes figure rather than clicking button
-if isempty(findobj('Tag',['Questionable Figure ' int2str(QueryFigh) ]))
+if isempty(findobj('Tag',['Questionable Figure ' int2str(QueryFighNr) ]))
   UserResponse = -1;
 else
   UserResponse = get(YesBh,'UserData');


### PR DESCRIPTION
Ha, fixed this somewhere on and old distro that didn't have your fixes from 2017 (they weren't willing to upgrade). In any case, GUI version of these now works with HG2. Have not tested with pre-hg2 matlabs as i don't have any. Is perhaps moot anyway, as I guess we don't really support those by now anymore?