### PR TITLE
- Use credit card and request to drivers.

### DIFF
--- a/Psychtoolbox/PsychCal/MeasureDpi.m
+++ b/Psychtoolbox/PsychCal/MeasureDpi.m
@@ -200,7 +200,7 @@ end
 
 function [unitInches, units, unit] = EnglishOrSI()
 % Ask user whether to use the International System of Units or the English
-% / Ameerican System(inches).
+% / American System(inches).
 inches=input('Do you prefer inches (1) or cm (0)? ');
         if inches
             unitInches=1;

--- a/Psychtoolbox/PsychCal/MeasureDpi.m
+++ b/Psychtoolbox/PsychCal/MeasureDpi.m
@@ -1,9 +1,16 @@
 function [dpi, SP]=MeasureDpi(theScreen, CC)
 % dpi=MeasureDpi([theScreen], [CC]);
+% Helps the user to accurately measure the screen's dots per inch. 
 % INPUT:
 % theScreen -> Screen parameter; 
 % CC-> Creditcard parameter, 1-> Yes. Other-> no
-% Helps the user to accurately measure the screen's dots per inch.
+% 
+% OUTPUT:
+% dpi-> Dots per inch.
+% SP -> Screen presets withdrawn from the Monitor drivers(EDID). It will provide
+% you with the physical size Width and Height, the screen resolution, the
+% DotPitch and dpi automatically. Note: This feature has not been tested in
+% Linux or MacOS, and it won't work with old monitors.
 %
 % Denis Pelli
 
@@ -27,9 +34,10 @@ function [dpi, SP]=MeasureDpi(theScreen, CC)
 if nargin>2 || nargout>2
     error([datestr(now),':>> Error wrong call to function, use it as: dpi=MeasureDpi(Screen)', newline, 'or [dpi, SP]=MeasureDpi(Screen, CC)']);
 end
-if isempty(theScreen)|| ~exist(theScreen)
-    theScreen=max(Screen('Screens')); %Use the second screen, most of the cases.
-    disp([datestr(now),':>> No screen value has been provided so I assume that you would like to use the secondary one...']);
+if ~exist(theScreen) || isempty(theScreen)
+    theScreen=max(Screen('Screens')); % Use the second screen, most of the cases.
+    disp([datestr(now),':>> No screen value has been provided so I assume ',...
+        'that either you would like to use the secondary screen, or the main one if you only have one...']);
 end
 AssertOpenGL;
 
@@ -39,29 +47,11 @@ try
         units='inches'; % e.g. distance in inches
         unit='inch';    % e.g. 5 inch object
         objectInches= 8.56*(1/2.54); % ID-1 format, ISO/IEC 7810 credit card (85.60 × 53.98 mm).
-        inches=input('Do you prefer inches (1) or cm (0)? ');
-        if inches
-            unitInches=1;
-            units='inches'; % e.g. distance in inches
-            unit='inch';    % e.g. 5 inch object
-        else
-            unitInches=1/2.54;
-            units='cm';
-            unit='cm';
-        end
+        [unitInches, units, unit] = EnglishOrSI();
     else
         disp('Please find an object of known width to hold against the display.');
         disp('E.g.  a ruler or an 8.5-inch page.');
-        inches=input('Do you prefer inches (1) or cm (0)? ');
-        if inches
-            unitInches=1;
-            units='inches'; % e.g. distance in inches
-            unit='inch';    % e.g. 5 inch object
-        else
-            unitInches=1/2.54;
-            units='cm';
-            unit='cm';
-        end
+        [unitInches, units, unit] = EnglishOrSI();
         objectInches=input(sprintf('How wide is your object, in %s? ',units))*unitInches;
         disp('A small correction will be made for your viewing distance and the thickness of');
         disp('the screen''s clear front plate, which separates your object from the screen''s');
@@ -82,9 +72,9 @@ try
     white=WhiteIndex(window);
     black=BlackIndex(window);
     
-    %This might work if you have a modern monitor with reasonable updated
-    %drivers and at least windows 10.
-    [SP.ScreenWidthOS, SP.ScreenHeightOS] = Screen('DisplaySize', max(Screen('Screens')));
+    % This might work if you have a modern monitor with reasonable updated
+    % drivers.
+    [SP.ScreenWidthOS, SP.ScreenHeightOS] = Screen('DisplaySize', theScreen);
     [SP.Xpixels, SP.Ypixels] = Screen('WindowSize', w);  
     SP.DotPitchX= (SP.ScreenWidthOS/SP.Xpixels);
     SP.DotPitchY=(SP.ScreenHeightOS/SP.Ypixels);
@@ -207,3 +197,17 @@ catch
     sca;
     psychrethrow(psychlasterror);
 end
+
+function [unitInches, units, unit] = EnglishOrSI()
+% Ask user whether to use the International System of Units or the English
+% / Ameerican System(inches).
+inches=input('Do you prefer inches (1) or cm (0)? ');
+        if inches
+            unitInches=1;
+            units='inches'; % e.g. distance in inches
+            unit='inch';    % e.g. 5 inch object
+        else
+            unitInches=1/2.54;
+            units='cm';
+            unit='cm';
+        end


### PR DESCRIPTION
- Included an optional input to request the user to use a ID/credit card instead of looking for an object. This can be handy as it is a common object of a known size.

- Included an output to request the drivers for the resolution and screen size. (It will only work on modern monitors with updated drivers).
