### PR TITLE
Update ClockRandSeed.m to accept struct input

### DIFF
--- a/Psychtoolbox/PsychProbability/ClockRandSeed.m
+++ b/Psychtoolbox/PsychProbability/ClockRandSeed.m
@@ -97,7 +97,11 @@ end
 
 % If we get to this point, then user wants total control:
 if exist('rng')
-  rng(seed, whichGen);
+  if isstruct(seed) % later Matlab return struct by rng()
+    rng(seed);
+  else
+    rng(seed, whichGen);
+  end
 else
   rand(whichGen,seed);
   randn(whichGen,seed);


### PR DESCRIPTION
Later Matlab rng() returns seed as a struct. When passing this struct into ClockRandSeed, it will give error "Too many input arguments.". This minor revision takes care of this.