### PR TITLE
DrawFormattedText2: Fix UTF-8 string handling WRT Octave 6

### DIFF
--- a/Psychtoolbox/PsychBasic/DrawFormattedText2.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText2.m
@@ -249,6 +249,7 @@ function [nx, ny, textbounds, cache, wordbounds] = DrawFormattedText2(varargin)
 % History:
 % 2015--2017    Written (DCN).
 % 7-May-2017    Add support for 'wordbounds' - per word bounding boxes (MK).
+% 18-Apr-2021   Fix UTF-8 string handling WRT new Octave 6 regexp behavior (MR).
 
 
 global ptb_drawformattedtext2_disableClipping;
@@ -887,6 +888,7 @@ function [tstring,fmtCombs,fmts,switches,previous] = getFormatting(win,tstring,s
 % get string type, store original as octave can't deal with string values outside uint8 range
 tstringOri  = tstring;
 tstring     = char(tstring);
+tstring(tstring>127) = 0;
 
 % get colorrange of window, to interpret colors
 cr = Screen('ColorRange',win);


### PR DESCRIPTION
With Octave 6, regexp expects strings to be truly UTF-8 encoded. This causes an "regexp: the input string is invalid UTF-8" error when calling DrawFormattedText2 with a vector that contains UTF character codes between 128 and 255, for example UTF-code 252 (umlaut-u). This can be easily reproduced with DrawFormattedText2Demo by inserting code 252 into the "unicodetext" vector near line 600.
As a workaround, we replace UTF codes >127 by zero rather than just replacing codes >255 by zero as it has been done so far.
This also works for Matlab.