### PR TITLE
AMD/Windows: Undo gfxhwtype=5 "fix"

### DIFF
--- a/Psychtoolbox/PsychOneliners/LoadIdentityClut.m
+++ b/Psychtoolbox/PsychOneliners/LoadIdentityClut.m
@@ -72,12 +72,17 @@ function oldClut = LoadIdentityClut(windowPtr, loadOnNextFlip, lutType, disableD
 %                identity lut via LoadNormalizedGammaTable before using low-level
 %                identity lut setup, which can only deal with discrete lut's, not
 %                pwl lut's or such.
-% 07/10/17   MR  Added gfxhwtype=5 for AMD graphics cards under Windows (see also 
+% 07/10/17   mr  Added gfxhwtype=5 for AMD graphics cards under Windows (see also 
 %                the new variable 'ditherApiVer').
 % 06/13/19   mk  Use gfxhwtype=0 on modern AMD DCE-10+ / DCN gpu's in the Linux
 %                fallback path. It's the right choice for Linux 5.3+ with DC, and
 %                especially crucial on DCN APUs if we really want to do without
 %                dedicated low-level setup code for these new GPU gen's.
+% 02/22/23   mr  Revert to always using gfxhwtype=0 for AMD graphics cards under  
+%                Windows (instead of gfxhwtype=5 if GPUCoreId=='R600' and 
+%                ditherApiVer==2 - see 07/10/17). This is because, meanwhile, 
+%                AMD has fixed the gfxhwtype=0 issues in their drivers, now making 
+%                gfxhwtype=5 a bad choice.
 
 global ptb_original_gfx_cluts;
 
@@ -316,16 +321,8 @@ else
                     % At least the Radeon HD 3470 under Windows Vista and Linux needs type 0
                     % LUT's. Let's assume for the moment this is true for all R600
                     % cores, ie., all Radeon HD series cards.
-                    % gfxhwtype==0 does not work for newer drivers. Since the driver version seems 
-                    % to be less indicative for the change, we base our decision on the dither API 
-                    % version implemented by AMD's display library (ADL). 
-                    if ditherApiVer==2
-                        fprintf('LoadIdentityClut: ATI Radeon HD-2000 or later with dither API v2 detected. Using type-5 LUT.\n');
-                        gfxhwtype = 5;
-                    else
-                        fprintf('LoadIdentityClut: ATI Radeon HD-2000 or later detected. Using type-0 LUT.\n');
-                        gfxhwtype = 0;
-                    end
+                    fprintf('LoadIdentityClut: ATI Radeon HD-2000 or later detected. Using type-0 LUT.\n');
+                    gfxhwtype = 0;
                 elseif IsLinux
                     % AMD GPU with DCE 10+ display engine or with a DCN display engine?
                     % If so, this will use AMD DisplayCore by default and starting with Linux 4.17


### PR DESCRIPTION
In 07/10/17,  gfxhwtype=5 was introduced and chosen as default for AMD cards under Windows if GPUCoreId=='R600' and ditherApiVer==2. Back then, this fixed mapping glitches in the gamma table with "newer" graphics card drivers (for which ditherApiVer==2 was supposed to be an indicator). Meanwhile, this fix is not necessary anymore. In fact, now gfxhwtype=5 shows mapping glitches. Tested with several Win10 versions, AMD drivers, video ports (DP, DVI, DP++/DVI) and AMD cards (HD-7750, R7-250X, R7-260X, RX-550, RX-6400, WX-5100) - although not all combinations of these. 
The bottom line: nowadays, gfxhwtype=0 is always good, gfxhwtype=5 is mostly bad. 
If gfxhwtype=5 has glitches, it is always that the gamma table output is shifted by -1 within a code range starting at somewhere between 9 to 45 and ending, if at all, at 255, consistently across the three color channels though. Which code range is affected, within the mentioned limits, depends on the graphics card, the output port, and what not else. For example, for the Radeon RX550, the codes 9-254 would map to 8-253, but only for DP and DP++/DVI, whereas all is fine with DVI, at least with an older driver. With newer drivers, the mapping is screwed up also with DVI.