### PR TITLE
Add `'left'` option to `DrawFormattedText`s `sx` argument which positions text based on left `winRect` bound

### DIFF
--- a/Psychtoolbox/PsychBasic/DrawFormattedText.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText.m
@@ -17,11 +17,11 @@ function [nx, ny, textbounds, wordbounds] = DrawFormattedText(win, tstring, sx, 
 %
 % 'sx' defines the left border of the text: If it is left out, text
 % starts at x-position zero, otherwise it starts at the specified position
-% 'sx'. If sx=='left', then each line of text is left justified to
-% the left border of the target window, or of 'winRect', if provided.
+% 'sx' in the window. If sx=='left', then each line of text is left justified
+% to the left border of the target window, or of 'winRect', if provided.
 % If sx=='center', then each line of text is horizontally centered in
-% the window. If sx=='right', then each line of text is right justified to
-% the right border of the target window, or of 'winRect', if provided.
+% the window or 'winRect'. If sx=='right', then each line of text is right
+% justified to the right border of the target window, or of 'winRect'.
 % The options sx == 'wrapat' and sx == 'justifytomax' try to align the start
 % of each text line to the left border and the end of each text line to either
 % the specified 'wrapat' number of columns, or to the width of the widest line

--- a/Psychtoolbox/PsychBasic/DrawFormattedText.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText.m
@@ -17,7 +17,9 @@ function [nx, ny, textbounds, wordbounds] = DrawFormattedText(win, tstring, sx, 
 %
 % 'sx' defines the left border of the text: If it is left out, text
 % starts at x-position zero, otherwise it starts at the specified position
-% 'sx'. If sx=='center', then each line of text is horizontally centered in
+% 'sx'. If sx=='left', then each line of text is left justified to
+% the left border of the target window, or of 'winRect', if provided.
+% If sx=='center', then each line of text is horizontally centered in
 % the window. If sx=='right', then each line of text is right justified to
 % the right border of the target window, or of 'winRect', if provided.
 % The options sx == 'wrapat' and sx == 'justifytomax' try to align the start
@@ -198,11 +200,16 @@ if nargin < 3 || isempty(sx)
 end
 
 xcenter = 0;
+ljustify = 0;
 rjustify = 0;
 bjustify = 0;
 if ischar(sx)
     if strcmpi(sx, 'center')
         xcenter = 1;
+    end
+
+    if strcmpi(sx, 'left')
+        ljustify = 1;
     end
 
     if strcmpi(sx, 'right')
@@ -366,7 +373,7 @@ end
 disableClip = (ptb_drawformattedtext_disableClipping ~= -1) && ...
               ((ptb_drawformattedtext_disableClipping > 0) || (nargout >= 3));
 
-if bjustify
+if bjustify || ljustify
     sx = winRect(RectLeft);
 end
 

--- a/Psychtoolbox/PsychBasic/DrawFormattedText.m
+++ b/Psychtoolbox/PsychBasic/DrawFormattedText.m
@@ -204,28 +204,19 @@ ljustify = 0;
 rjustify = 0;
 bjustify = 0;
 if ischar(sx)
-    if strcmpi(sx, 'center')
-        xcenter = 1;
-    end
-
-    if strcmpi(sx, 'left')
-        ljustify = 1;
-    end
-
-    if strcmpi(sx, 'right')
-        rjustify = 1;
-    end
-
-    if strcmpi(sx, 'wrapat')
-        bjustify = 1;
-    end
-
-    if strcmpi(sx, 'justifytomax')
-        bjustify = 2;
-    end
-
-    if strcmpi(sx, 'centerblock')
-        bjustify = 3;
+    switch lower(sx)
+        case 'center'
+            xcenter = 1;
+        case 'left'
+            ljustify = 1;
+        case 'right'
+            rjustify = 1;
+        case 'wrapat'
+            bjustify = 1;
+        case 'justifytomax'
+            bjustify = 2;
+        case 'centerblock'
+            bjustify = 3;
     end
 
     % Set sx to neutral setting:


### PR DESCRIPTION
Fixes #817

I solved it by adding a new mode 'left'. This way exisitng code is not broken. The default value of 0 still refers to the left edge of the screen rather than of the `winRect`. Using `sx = 'left'`, it will take the left bound into consideration.


I just tested a few basic cases, here are the screenshots from it:
`DrawFormattedText` with `sx = 'left'` and a grey `winRect` offset to the right:
![left](https://github.com/Psychtoolbox-3/Psychtoolbox-3/assets/39488412/76139886-0517-46c0-93c5-8e79d1b62477)
`DrawFormattedText` with `sx = 'left'` and a grey `winRect` offset to the left:
![left](https://github.com/Psychtoolbox-3/Psychtoolbox-3/assets/39488412/d1a3c236-4f28-4c84-a10f-07dd85aa4721)
(more testing is probably required)

I used the same reproduce.m file as in the issue.
Just replaced `displayTextInRect(window, padding, 0);` with `displayTextInRect(window, padding, 'left');`

