### PR TITLE
Fix typo in DegreesToRetinalEccentricityMM.m

### DIFF
--- a/Psychtoolbox/PsychColorimetricData/DegreesToRetinalEccentricityMM.m
+++ b/Psychtoolbox/PsychColorimetricData/DegreesToRetinalEccentricityMM.m
@@ -118,7 +118,7 @@ switch (method)
         degreeThreshold = 0.2;
         index = find(eccDegrees < degreeThreshold);
         if (~isempty(index))
-            eccMM(index) = DegreesToRetinalMM(eccDegrees(index),eyeLengthMm,false);
+            eccMm(index) = DegreesToRetinalMM(eccDegrees(index),eyeLengthMm,false);
         end
 
     case 'Linear'


### PR DESCRIPTION
Corrected the variable name from `eccMM` to `eccMm`. The typo was affecting the linear approximation functionality for small < .02 degree angles.
