### PR TITLE
IOPort: Add BreakBehaviour and BreakBehaviour=IgnoreEarly (Windows only)

### DIFF
--- a/PsychSourceGL/Source/Common/IOPort/IOPort.c
+++ b/PsychSourceGL/Source/Common/IOPort/IOPort.c
@@ -369,7 +369,7 @@ PsychError IOPORTOpenSerialPort(void)
         "or on OS/X and Linux in 'Cooked' processing mode as line delimiter. A setting of -1 will try to disable the line terminator.\n\n"
         "DTR=os default    -- Setting for 'Data Terminal Ready' pin: 0 or 1.\n\n"
         "RTS=os default    -- Setting for 'Request To Send' pin: 0 or 1.\n\n"
-        "BreakBehaviour=Ignore -- Behaviour if a 'Break Condition' is detected on the line: Ignore, Flush, Zero. On Windows, this setting is ignored.\n\n"
+        "BreakBehaviour=Ignore -- Behaviour if a 'Break Condition' is detected on the line: Ignore, Flush, Zero. On Windows, it is Ignore (Default) or IgnoreEarly, where IgnoreEarly is a more low-level version of Ignore.\n\n"
         "OutputBufferSize=4096 -- Size of output buffer in bytes.\n\n"
         "InputBufferSize=4096 -- Size of input buffer in bytes. You can't read more than that amount per read command.\n\n"
         "HardwareBufferSizes=input,output -- Set size of the hardware driver internal input and output buffers in bytes. "

--- a/PsychSourceGL/Source/Windows/IOPort/PsychSerialWindowsGlue.h
+++ b/PsychSourceGL/Source/Windows/IOPort/PsychSerialWindowsGlue.h
@@ -55,6 +55,7 @@ typedef struct PsychSerialDeviceRecord {
     unsigned char       lineTerminator;                 // Line terminator byte, if any.
     unsigned char       eventCharEnabled;               // 0 = Waiting for "event character received" event is disabled. Otherwise it is enabled.
     int                 dontFlushOnWrite;               // If set to 1, don't tcdrain() after blocking writes, otherwise do.
+    int                 breakBehaviour;                 // 0: Ignore (report error, possibly drop data) 1: IgnoreEarly
 } PsychSerialDeviceRecord;
 
 #endif


### PR DESCRIPTION
* Added a windows-specific option for making IOPort ignore break conditions completely.
* Used the BreakBehaviour parameter, which is already known (Linux and MacOS version).
* BreakBehaviour=Ignore: Default, corresponding to the behaviour as implemented so far.
* BreakBehaviour=IgnoreEarly: A more thorough Ignore, i.e., no error reporting, no discarding of data.