### PR TITLE
Bugfix: post icmconfig to shader also in HDR mode

### DIFF
--- a/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
+++ b/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
@@ -4426,7 +4426,7 @@ end
 % conversion.
 icmshader = [];
 icmstring = [];
-icmconfig = [];
+icmconfig = '';
 icmformatting_downstream = 0;
 
 floc = find(mystrcmp(reqs, 'DisplayColorCorrection'));
@@ -5544,7 +5544,7 @@ if useHDR
             Screen('HookFunction', win, 'AppendBuiltin', 'FinalOutputFormattingBlit', 'Builtin:FlipFBOs', '');
         end
 
-        Screen('HookFunction', win, 'AppendShader', 'FinalOutputFormattingBlit', hdrShaderString, hdrShader, '');
+        Screen('HookFunction', win, 'AppendShader', 'FinalOutputFormattingBlit', hdrShaderString, hdrShader, icmconfig);
         Screen('HookFunction', win, 'Enable', 'FinalOutputFormattingBlit');
         outputcount = outputcount + 1;
     end


### PR DESCRIPTION
Such that PsychColorCorrection works as intended. This makes it so that the CLUT texture is actually passed to the shader program