### PR TITLE
Fix 'AttributeError' raised when creating a stream fails

### DIFF
--- a/PsychPython/psychtoolbox/audio.py
+++ b/PsychPython/psychtoolbox/audio.py
@@ -133,7 +133,9 @@ class Stream:
 
     def close(self):
         """Close the current stream"""
-        if getattr(self, '_closed', False): # if we're already closed don't try again
+        if not hasattr(self, 'handle') or getattr(self, '_closed', False): 
+            # if we're already closed or the `handle` attribute doesn't exist, 
+            # then we don't need to close anything
             return
         try:
             PsychPortAudio('Close', self.handle)


### PR DESCRIPTION
New PR with correct commit message.

Summary from the previous PR: 

Small change that prevents an AttributeError from being raised when the Stream.close() method is called. This occurs mostly when the __del__ method is called during garbage collection on a Stream object that encountered an error during initialization. When an error occurs inside the PsychPortAudio('Open', ...) command, the attribute handle is never created. When the object is garbage collected afterwards, there is a call to PsychPortAudio('Close', self.handle) but self.handle does not exist, resulting in an AttributeError.

This change simply checks if there is a self.handle attribute before calling PsychPortAudio('Close', ...).

