### PR TITLE
PTB beta update Psychtoolbox 3.0.20.1 "Appletizer SP1"

### DIFF
--- a/Psychtoolbox/PsychDemos/BasicAMAndMixScheduleDemo.m
+++ b/Psychtoolbox/PsychDemos/BasicAMAndMixScheduleDemo.m
@@ -42,7 +42,7 @@ InitializePsychSound;
 nrchannels = 2;
 sugLat = [];
 
-if IsARM
+if IsARM && IsLinux
     % ARM processor, probably the RaspberryPi SoC. The Pi can not quite handle the
     % low latency settings of a desktop PC, so be more lenient:
     sugLat = 0.025;

--- a/Psychtoolbox/PsychDemos/BasicSoundScheduleDemo.m
+++ b/Psychtoolbox/PsychDemos/BasicSoundScheduleDemo.m
@@ -86,7 +86,7 @@ nrchannels = 2;
 InitializePsychSound;
 
 suggestedLatencySecs = [];
-if IsARM
+if IsARM && IsLinux
     % ARM processor, probably the RaspberryPi SoC. This can not quite handle the
     % low latency settings of a Intel PC, so be more lenient:
     suggestedLatencySecs = 0.025;

--- a/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
+++ b/Psychtoolbox/PsychGLImageProcessing/PsychImaging.m
@@ -1952,7 +1952,7 @@ if strcmpi(cmd, 'OpenWindow')
         % Force the UseVulkanDisplay task if it doesn't exist already if running
         % on macOS for Apple Silicon, as that is the only display backend which
         % can ensure proper visual stimulus presentation timing and timestamping:
-        if IsOSX && IsARM && isempty(find(mystrcmp(reqs, 'UseVulkanDisplay')))
+        if IsOSX && IsARM(1) && isempty(find(mystrcmp(reqs, 'UseVulkanDisplay')))
             % Only auto-enable Vulkan backend for opaque top-level fullscreen windows:
             if ((isempty(winRect) || isequal(winRect, Screen('Rect', screenid)) || isequal(winRect, Screen('GlobalRect', screenid))) && ...
                (Screen('Preference', 'WindowShieldingLevel') >= 2000) && (bitand(Screen('Preference', 'ConserveVRAM'), 8192) == 0))
@@ -3750,8 +3750,8 @@ if ~isempty(floc)
     % overriden to something higher precision:
     vulkanColorPrecision = 0;
 
-    % Apple macOS needs special treatment:
-    if IsOSX && IsARM
+    % Apple macOS for Apple Silicon needs special treatment:
+    if IsOSX && IsARM(1)
         % VK_COLOR_SPACE_PASS_THROUGH_EXT for pixel identity passthrough, or this
         % will mess with our own color correction routines and with display on
         % devices from VPixx and CRS and similar:

--- a/Psychtoolbox/PsychGLImageProcessing/PsychVulkan.m
+++ b/Psychtoolbox/PsychGLImageProcessing/PsychVulkan.m
@@ -442,7 +442,7 @@ if strcmpi(cmd, 'OpenWindowSetup')
             end
         end
 
-        if ~isempty(outputName) && ((verbosity >= 4) || (~(IsOSX && IsARM) && (verbosity == 3)))
+        if ~isempty(outputName) && ((verbosity >= 4) || (~(IsOSX && IsARM(1)) && (verbosity == 3)))
             fprintf('PsychVulkan-INFO: Onscreen window at rect [%i, %i, %i, %i] is aligned with fullscreen exclusive output for screenId %i.\n', ...
                     winRect(1), winRect(2), winRect(3), winRect(4), screenId);
         end
@@ -621,12 +621,12 @@ if strcmpi(cmd, 'PerformPostWindowOpenSetup')
             % frame latency is gone, but now stimulus onset scheduling is
             % broken whenever a flip is more than 2 frames in the future!
             %
-            % On macOS 14.4 on Apple M1, it seems to work reasonably well,
+            % On macOS 14.4+ on Apple M1, it seems to work reasonably well,
             % apart from the sporadic failure during the first few
             % presents, so there's some hope. Not yet tested thoroughly
             % yet, but lets activate this mode on Apple Silicon for now.
             % Broken stuff all around on the iToys operating system:
-            if ~IsARM
+            if ~IsARM(1)
                 flags = mor(flags, 2);
             end
         else

--- a/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusIdentityClutTest.m
+++ b/Psychtoolbox/PsychHardware/BitsPlusToolbox/BitsPlusTests/BitsPlusIdentityClutTest.m
@@ -135,7 +135,7 @@ try
         PsychImaging('AddTask', 'General', 'UseVulkanDisplay');
     else
         % Will Vulkan auto-enable on macOS for Apple Silicon machines?
-        if IsOSX && IsARM && (Screen('Preference', 'WindowShieldingLevel') == 2000)
+        if IsOSX && IsARM(1) && (Screen('Preference', 'WindowShieldingLevel') == 2000)
             % Yes:
             useVulkan = 1;
             winrect = [];

--- a/Psychtoolbox/PsychOneliners/Contents.m
+++ b/Psychtoolbox/PsychOneliners/Contents.m
@@ -48,7 +48,7 @@
 %   Ind2Str                 - Converts numbers to characters (decimal to base 26 conversion). Useful for character indices.
 %   Interleave              - Interleaves any number of arrays. Can handle different data types.
 %   IsACell                 - Tests (recursively--cells in cells) if a cell satisfies a user-supplied condition.
-%   IsARM                   - Return if running on a processor with ARM architecture, typically a mobile or embedded system.
+%   IsARM                   - Return if running on a runtime or processor with ARM architecture.
 %   IsGLES                  - Return if the current rendering api in use is OpenGL-ES, the "OpenGL Embedded Subset".
 %   IsGLES1                 - Return if the current rendering api in use is OpenGL-ES 1.x.
 %   IsGUI                   - Is the Matlab or Octave GUI enabled in this session?

--- a/Psychtoolbox/PsychOneliners/IsARM.m
+++ b/Psychtoolbox/PsychOneliners/IsARM.m
@@ -1,15 +1,52 @@
-function resultFlag = IsARM
-% resultFlag = IsARM
+function resultFlag = IsARM(wantTrueHostArch)
+% resultFlag = IsARM([wantTrueHostArch=0])
 %
-% Returns true if the processor architecture is ARM.
+% By default (if wantTrueHostArch omitted or false) returns true if the
+% cpu architecture for which Octave or Matlab and Psychtoolbox mex files
+% are built is ARM. Otherwise it returns false.
+%
+% If wantTrueHostArch is true, then return the true machine processor
+% architecture of the host computer and operating system. This matters if
+% one is running Psychtoolbox on a non-native Octave or Matlab on a ARM
+% operating system + machine via some emulation layer, e.g., most commonly
+% Octave/Matlab for Apple Intel Macs on an Apple Silicon Mac via Rosetta2
+% emulation.
+%
+% Note: True machine detection is currently only implemented for macOS,
+% otherwise we assume scripting runtime architecture == true architecture
+% for now.
 
 % HISTORY
 % 04.04.2013 mk   Wrote it.
-% 16.12.2023 mk   Simplify and make more robust and recognize Apple Silicon. 
+% 16.12.2023 mk   Simplify and make more robust and recognize Apple Silicon.
+% 11.01.2025 mk   Optionally return true architecture of host machine + OS.
 
 persistent rc;
+persistent mrc;
+
 if isempty(rc)
-     rc = ~isempty(strfind(computer, 'arm-')) || ~isempty(strfind(computer, 'aarch')) || streq(computer, 'MACA64'); %#ok<STREMP>
+    rc = ~isempty(strfind(computer, 'arm-')) || ~isempty(strfind(computer, 'aarch')) || streq(computer, 'MACA64'); %#ok<*STREMP>
+
+    if IsOSX
+        % macOS: Rosetta2 emulation allows running Matlab/Octave for 64-Bit
+        % Intel to run on 64-Bit ARM, so can't rely on computer() to find
+        % out the true machine architecture of the underlying OS and HW:
+        [s, resp] = system('uname -a');
+        if s == 0
+            mrc = ~isempty(strfind(resp, 'ARM64'));
+        else
+            mrc = rc;
+            warning('IsARM(): Could not determine true host system machine architecture [%s]. Going with arch of scripting runtime. This may go sideways!', resp);
+        end
+    else
+        % Others: For now, just assume actual host machine architecture is
+        % architecture for which the scripting environment was built:
+        mrc = rc;
+    end
 end
 
-resultFlag = rc;
+if (nargin == 1) && ~isempty(wantTrueHostArch) && wantTrueHostArch
+    resultFlag = mrc;
+else
+    resultFlag = rc;
+end

--- a/Psychtoolbox/PsychTests/PsychPortAudioDataPixxTimingTest.m
+++ b/Psychtoolbox/PsychTests/PsychPortAudioDataPixxTimingTest.m
@@ -126,7 +126,7 @@ freq = 44100;       % Must set this. 44.1 khz most likely to work, as shown by e
 buffersize = 0;     % Pointless to set this. Auto-selected to be optimal.
 suggestedLatencySecs = [];
 
-if IsARM
+if IsARM && IsLinux
     % ARM processor, probably the RaspberryPi SoC. This can not quite handle the
     % low latency settings of a Intel PC, so be more lenient:
     suggestedLatencySecs = 0.025;

--- a/Psychtoolbox/PsychTests/PsychPortAudioTimingTest.m
+++ b/Psychtoolbox/PsychTests/PsychPortAudioTimingTest.m
@@ -128,7 +128,7 @@ freq = 44100;       % Must set this. 44.1 khz most likely to work, as shown by e
 buffersize = 0;     % Pointless to set this. Auto-selected to be optimal.
 suggestedLatencySecs = [];
 
-if IsARM
+if IsARM && IsLinux
     % ARM processor, probably the RaspberryPi SoC. This can not quite handle the
     % low latency settings of a Intel PC, so be more lenient:
     suggestedLatencySecs = 0.025;

--- a/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
+++ b/Psychtoolbox/PsychtoolboxPostInstallRoutine.m
@@ -167,27 +167,18 @@ catch
     fprintf('Info: Failed to remove .svn subfolders from path. Not a big deal...\n');
 end
 
-% No Apple Silicon Matlab/Octave support yet. Only Rosetta 2 emulated Intel.
-if IsOSX && IsARM && ~exist('WaitSecs.mexmaca64', 'file')
-    fprintf('Psychtoolbox does not yet work on native Matlab or Octave for Apple Silicon Macs with 64-Bit ARM architecture.\n');
-    fprintf('You may get a minimally functional Psychtoolbox by installing and running Matlab or Octave for 64-Bit Intel\n');
-    fprintf('under Rosetta 2 emulation.\n');
-    error('Tried to setup on native Matlab or Octave for Apple Silicon 64-Bit ARM. This is not supported.');
-end
-
 % 32-Bit Octave or 32-Bit Matlab on OSX? This is unsupported as of Version 3.0.11.
-if (IsOSX || IsWin) && ~Is64Bit
-    fprintf('Psychtoolbox 3.0.13 and later versions do no longer work with 32-Bit versions of Octave or Matlab on OSX or Windows.\n');
+if ~IsLinux && ~Is64Bit
+    fprintf('Psychtoolbox no longer works with 32-Bit versions of Octave or Matlab on macOS or Windows.\n');
     fprintf('You need to upgrade to a 64-Bit version of Octave or Matlab on these systems, which is fully supported.\n');
-    fprintf('You can also use the alternate download function DownloadLegacyPsychtoolbox() to download\n');
-    fprintf('an old legacy copy of Psychtoolbox-3.0.9, which did support 32-Bit Octave 3.2 on OSX, or use\n');
-    fprintf('DownloadPsychtoolbox() with flavor ''Psychtoolbox-3.0.10'', which does support 32-Bit Matlab on OSX.\n');
-    fprintf('DownloadPsychtoolbox() with flavor ''Psychtoolbox-3.0.12'', does support 32-Bit Octave-4 on Windows.\n');
-    error('Tried to setup on 32-Bit Octave or Matlab, which is no longer supported on OSX or Windows.');
+    fprintf('Psychtoolbox-3.0.9 was the last to support 32-Bit Octave 3.2 on macOS.\n');
+    fprintf('Psychtoolbox-3.0.10 was the last to support 32-Bit Matlab on macOS.\n');
+    fprintf('Psychtoolbox-3.0.12 was the last to support 32-Bit Octave-4 on Windows.\n');
+    error('Tried to setup on 32-Bit Octave or Matlab, which is no longer supported on macOS or Windows.');
 end
 
 if IsLinux && ~Is64Bit && IsOctave && ~IsARM
-    fprintf('Psychtoolbox 3.0.15 and later no longer provide mex files for 32-Bit Octave for Intel on Linux.\n');
+    fprintf('Psychtoolbox no longer works with 32-Bit Octave for Intel on Linux.\n');
     fprintf('The only exception is 32-Bit Octave for Linux on ARM processors like the RaspberryPi.\n');
     fprintf('Not to worry though, you can get a supported Psychtoolbox 3.0.15+ for 32-Bit Octave\n');
     fprintf('on Linux from the NeuroDebian project if you run Debian GNU/Linux or a Ubuntu flavor.\n');
@@ -198,11 +189,11 @@ if IsLinux && ~Is64Bit && IsOctave && ~IsARM
 end
 
 if ~Is64Bit && ~IsOctave
-    fprintf('Psychtoolbox 3.0.12 and later do no longer work with 32-Bit versions of Matlab.\n');
+    fprintf('Psychtoolbox no longer works with 32-Bit versions of Matlab.\n');
     fprintf('You need to upgrade to a supported 64-Bit version of Octave or Matlab. 32-Bit Octave is still\n');
     fprintf('supported on GNU/Linux.\n');
-    fprintf('If you must use a legacy 32-Bit Matlab environment, you can call the function\n');
-    fprintf('DownloadPsychtoolbox() with flavor ''Psychtoolbox-3.0.11'', which does support 32-Bit Matlab on Linux and Windows.\n');
+    fprintf('If you must use a legacy 32-Bit Matlab environment, then legacy\n');
+    fprintf('Psychtoolbox-3.0.11 does support 32-Bit Matlab on Linux and Windows.\n');
     error('Tried to setup on 32-Bit Matlab, which is no longer supported.');
 end
 


### PR DESCRIPTION
### Compatibility changes wrt. Psychtoolbox 3.0.20.0:

- None

### Highlights:

- None

## macOS:

- Psychtoolbox was built and tested against native Matlab R2024b and against native
  Octave 9.3 from HomeBrew, on macOS 13.7.1 Ventura for Intel Macs, and on macOS 14.5
  Sonoma for Apple Silicon Macs.

- Try to execute same code path on Apple Silicon macOS, regardless if running under native
  Matlab/Octave for Apple Silicon ARM, or running under Intel Matlab/Octave via Rosetta2
  emulation. Our license management aggregate stats tell us that a non-trivial fraction of users
  still use Matlab for Intel Macs via Rosetta2 emulation on Apple Silicon, instead of the recommended
  native Matlab/Octave for Apple Silicon. This would cause PTB to misbehave, as it would think it runs
  on an Intel Mac and acts accordingly, instead of adapting to the special snowflake that is macOS on
  Apple Silicon. This will especially cause trouble with visual stimulation timing and some visual stimulus
  presentation. Note that this fix tries to fix this, but Psychtoolbox is not and will not be tested for proper
  compatibility and quality when running under Matlab/Octave for Intel via Rosetta2 on Apple Silicon!
  Switching to native Matlab/Octave for Apple Silicon / ARM is strongly recommended.

- Audio demos and tests: Request standard latency instead of larger latency on Apple Silicon.
  The lose latency requirement was only meant to accomodate RaspberryPi's, not Apple Silicon.