### PR TITLE
Update PR655parsespdstr.m to handle zero values

### DIFF
--- a/Psychtoolbox/PsychHardware/PR655Toolbox/PR655parsespdstr.m
+++ b/Psychtoolbox/PsychHardware/PR655Toolbox/PR655parsespdstr.m
@@ -11,6 +11,7 @@ if nargin < 2 || isempty(S)
 	S = [380 5 81];
 end
 
+readStr = strrep(readStr,'0.000e+000','0.000e+00');
 start = findstr(readStr,'380,');
 for k= 1:101
     %fprintf('k: %d, bi: %d, ed: %d\n', k, start+6+17*(k-1), start+6+9+17*(k-1));


### PR DESCRIPTION
`PR655parsespdstr` expects values to be 9 values long. 0 is encoded as `0.000e+000` however, which is 10 characters long, and this breaks the parser. This PR is a little tweak removes the final 0 of any `0.000e+000`s to make it 9 characters long.

I don't know whether this should be added to [the PR650 equivalent](https://github.com/Psychtoolbox-3/Psychtoolbox-3/blob/master/Psychtoolbox/PsychHardware/PR650Toolbox/PR650parsespdstr.m).

The parser works [differently for the PR670](https://github.com/Psychtoolbox-3/Psychtoolbox-3/blob/1d7b325a28b3f422bef17086d144694e9be9acd3/Psychtoolbox/PsychHardware/PR670Toolbox/PR670parsespdstr.m#L21-L42) and differently yet again for the [705](https://github.com/Psychtoolbox-3/Psychtoolbox-3/blob/1d7b325a28b3f422bef17086d144694e9be9acd3/Psychtoolbox/PsychHardware/PR705Toolbox/PR705parsespdstr.m#L22-L46), and some quick testing suggests that both of those approaches would work fine with PR655 data (I could test PR650 data sometime if that would be useful).

For elegance, I think all 4 code chunk should be switched over to the 705 option (or even refactored into a single function). However, this might have unanticipated breaking changes, in which case, the little tweak suggested in this PR seems like an alternative option with the least risk involved.